### PR TITLE
fix: clean clone does not build -- missing switch_compat.c implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ APP_ICON    := icon.jpg
 TARGET   := green-nx
 BUILD    := build-switch
 SOURCES  := src/core src/switch
-INCLUDES := src vendor
+INCLUDES := src vendor deps/shim/include
 ROMFS    := romfs
 
 DEFINES := -DGNX_VERSION=\"$(APP_VERSION)\"

--- a/src/switch/stream/switch_compat.c
+++ b/src/switch/stream/switch_compat.c
@@ -22,6 +22,7 @@
 #include <switch.h>
 #include <unistd.h>
 
+#include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netinet/in.h>

--- a/src/switch/stream/switch_compat.c
+++ b/src/switch/stream/switch_compat.c
@@ -1,0 +1,114 @@
+/* Symbols the WebRTC deps expect the Switch build to provide. The shim
+ * headers in deps/shim/include declare these (and note they used to live in a
+ * switch_compat.c inside libpeer's tree that never shipped with the repo);
+ * defining them app-side resolves them at the final link just the same, so a
+ * clean clone builds without hand-edits to deps/src.
+ *
+ *  - peer_log / gnx_peer_log_set: libpeer's LOG_REDIRECT sink (see
+ *    deps/build-switch.sh, -DLOG_REDIRECT=1) routed to stream::Engine's log.
+ *  - getifaddrs/freeifaddrs, if_nametoindex/if_indextoname: newlib/libnx has
+ *    none; libpeer's ICE host-candidate scan and usrsctp's init want them.
+ *  - mbedtls_hardware_poll: mbedtls is built with MBEDTLS_ENTROPY_HARDWARE_ALT
+ *    (no /dev/urandom on HOS); back it with the system csrng.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __SWITCH__
+
+#include <switch.h>
+#include <unistd.h>
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+/* ---- libpeer LOG_REDIRECT sink ------------------------------------------ */
+
+static void (*g_peer_log_cb)(const char* line);
+
+void gnx_peer_log_set(void (*cb)(const char* line)) { g_peer_log_cb = cb; }
+
+void peer_log(char* level_tag, const char* file, int line, const char* fmt,
+              ...) {
+    if (!g_peer_log_cb) return;
+    char msg[384];
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(msg, sizeof(msg), fmt, ap);
+    va_end(ap);
+    char full[512];
+    snprintf(full, sizeof(full), "%s %s:%d %s", level_tag ? level_tag : "?",
+             file ? file : "?", line, msg);
+    g_peer_log_cb(full);
+}
+
+/* ---- ifaddrs ------------------------------------------------------------- */
+
+/* One AF_INET entry ("wlan0") holding the console's current IP from libnx
+ * gethostid(); that is all libpeer's host-candidate gathering needs. A single
+ * malloc block keeps freeifaddrs trivial. */
+
+struct gnx_ifaddrs_block {
+    struct ifaddrs ifa;
+    struct sockaddr_in addr;
+    struct sockaddr_in netmask;
+    char name[8];
+};
+
+int getifaddrs(struct ifaddrs** ifap) {
+    if (!ifap) return -1;
+    struct gnx_ifaddrs_block* block = calloc(1, sizeof(*block));
+    if (!block) return -1;
+
+    strcpy(block->name, "wlan0");
+    block->addr.sin_family = AF_INET;
+    block->addr.sin_addr.s_addr = (u32)gethostid();
+    block->netmask.sin_family = AF_INET;
+    block->netmask.sin_addr.s_addr = htonl(0xFFFFFF00);  /* /24 */
+
+    block->ifa.ifa_next = NULL;
+    block->ifa.ifa_name = block->name;
+    block->ifa.ifa_flags = IFF_UP | IFF_RUNNING;
+    block->ifa.ifa_addr = (struct sockaddr*)&block->addr;
+    block->ifa.ifa_netmask = (struct sockaddr*)&block->netmask;
+
+    *ifap = &block->ifa;
+    return 0;
+}
+
+void freeifaddrs(struct ifaddrs* ifa) {
+    while (ifa) {
+        struct ifaddrs* next = ifa->ifa_next;
+        free(ifa);  /* ifa is the first member of its gnx_ifaddrs_block */
+        ifa = next;
+    }
+}
+
+unsigned int if_nametoindex(const char* ifname) {
+    (void)ifname;
+    return 1;
+}
+
+char* if_indextoname(unsigned int ifindex, char* ifname) {
+    (void)ifindex;
+    if (!ifname) return NULL;
+    strcpy(ifname, "wlan0");
+    return ifname;
+}
+
+/* ---- mbedtls hardware entropy ------------------------------------------- */
+
+int mbedtls_hardware_poll(void* data, unsigned char* output, size_t len,
+                          size_t* olen) {
+    (void)data;
+    randomGet(output, len);
+    if (olen) *olen = len;
+    return 0;
+}
+
+#endif /* __SWITCH__ */


### PR DESCRIPTION
A fresh clone currently fails at link with undefined references to `peer_log`, `gnx_peer_log_set`, `getifaddrs`/`freeifaddrs`, `if_nametoindex`/`if_indextoname` and `mbedtls_hardware_poll`. The shim headers (`deps/shim/include/ifaddrs.h`) mention these live in a `switch_compat.c` inside libpeer's tree, but that file never shipped with the repo — `deps/build-switch.sh` clones pristine sepfy/libpeer and the shipped patches don't add it, so only a checkout that already has your local copy can build.

This PR provides those symbols app-side (`src/switch/stream/switch_compat.c`) instead of patching them into libpeer:
- `peer_log` / `gnx_peer_log_set`: LOG_REDIRECT sink routed to `stream::Engine`'s log, matching the signature in libpeer's `utils.h`;
- minimal `getifaddrs`: single AF_INET "wlan0" entry from libnx `gethostid()`, as the shim header describes;
- `mbedtls_hardware_poll` backed by the system csrng (`randomGet`);
- adds `deps/shim/include` to the app include path in the Makefile.

Same result at the final link, and `deps/src` stays pristine upstream + your patches. If your local `switch_compat.c` differs, happy to adjust to match — the goal is just that a clean clone builds again.

Note: the smoke-test link in `deps/build-switch.sh --inside` links the deps alone, so it can't resolve these app-side symbols; you may want to drop it or feed it a stub. Didn't touch it here to keep the diff minimal.

Verified: full .nro build passes in CI on my fork (devkitpro/devkita64 image, pristine clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)