### PR TITLE
feat: 'OLED premium' UI redesign

### DIFF
--- a/docs-design/green-nx-redesign.dc.html
+++ b/docs-design/green-nx-redesign.dc.html
@@ -1,0 +1,431 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics>
+<meta name="design_doc_mode" content="canvas">
+<link href="https://fonts.googleapis.com/css2?family=M+PLUS+1p:wght@400;500;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<style>
+body{margin:0;background:#1b1d22;font-family:'M PLUS 1p',system-ui,sans-serif}
+a{color:#7fd67f;text-decoration:none}a:hover{color:#a5e8a5}
+.dv-turn{padding:40px 44px 60px;scroll-margin-top:16px}
+.dv-thd{display:flex;align-items:baseline;gap:10px;margin:0 0 24px}
+.dv-tid{font:600 11px 'JetBrains Mono',monospace;padding:3px 8px;background:#107C10;color:#fff;text-decoration:none}
+.dv-tname{font:600 14px/1.2 'M PLUS 1p',sans-serif;color:#e8eaee}
+.dv-opts{display:flex;flex-wrap:wrap;gap:48px;align-items:flex-start}
+.dv-opt{flex:none;display:flex;flex-direction:column;gap:10px;scroll-margin-top:16px}
+.dv-oid{font:600 11px 'JetBrains Mono',monospace;padding:3px 8px;background:rgba(255,255,255,.12);color:#e8eaee;text-decoration:none}
+.dv-olabel{display:flex;align-items:baseline;gap:10px;font:400 12px/1.3 'M PLUS 1p',sans-serif;color:rgba(255,255,255,.55)}
+.dv-card{max-width:100%;background:#0A0D12;border:1px solid rgba(255,255,255,.1);overflow:hidden}
+.dv-opt:target .dv-oid{background:#107C10;color:#fff}
+.dv-note{width:1920px;box-sizing:border-box;background:#101319;border:1px solid rgba(255,255,255,.08);border-top:none;padding:14px 20px;font:400 12.5px/1.7 'JetBrains Mono',monospace;color:#8a93a3}
+.dv-note b{color:#c9d2df;font-weight:600}
+</style>
+</helmet>
+
+<section class="dv-turn" id="t1">
+<div class="dv-thd"><a class="dv-tid" href="#t1">1</a><span class="dv-tname">Rediseño green-nx — dirección "OLED premium" · lienzo 1920×1080 · solo primitivas SDL2 (rect relleno / marco / texto / textura)</span></div>
+<div class="dv-opts">
+
+<!-- ============ 1a SPEC ============ -->
+<div class="dv-opt" id="1a"><div class="dv-olabel"><a class="dv-oid" href="#1a">1a</a>Spec de diseño — paleta · tipografía · espaciado · sistema de foco</div>
+<div class="dv-card" style="width:1920px;box-sizing:border-box;padding:60px;display:flex;flex-direction:column;gap:48px;color:#F0F3F8" data-screen-label="Spec">
+<div style="display:flex;gap:60px">
+<div style="flex:1">
+<div style="font-size:26px;font-weight:800;color:#2FBF2F;margin-bottom:20px">PALETA</div>
+<div style="display:flex;flex-direction:column;gap:10px;font-size:16px">
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#0A0D12;border:1px solid #333"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#0A0D12</b><span style="color:#98A2B3">kBg — fondo global (OLED, casi negro)</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#0E1118;border:1px solid #333"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#0E1118</b><span style="color:#98A2B3">kBar — footer / bandas de cabecera</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#161B24"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#161B24</b><span style="color:#98A2B3">kSurface — tarjetas, filas, placas de nombre</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#212836"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#212836</b><span style="color:#98A2B3">kSurfaceHi — superficie enfocada / chips</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#107C10"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#107C10</b><span style="color:#98A2B3">kAccent — marca, tabs activas, valores</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#2FBF2F"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#2FBF2F</b><span style="color:#98A2B3">kFocus — SOLO para el sistema de foco (borde+glow)</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#F0F3F8"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#F0F3F8</b><span style="color:#98A2B3">kText — texto primario</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#98A2B3"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#98A2B3</b><span style="color:#98A2B3">kTextDim — texto secundario, hints</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#F0B43C"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#F0B43C</b><span style="color:#98A2B3">kWarn — favoritos, avisos</span></div>
+<div style="display:flex;align-items:center;gap:14px"><span style="width:56px;height:36px;background:#E86868"></span><b style="width:150px;font-family:'JetBrains Mono',monospace">#E86868</b><span style="color:#98A2B3">kError — errores</span></div>
+</div>
+</div>
+<div style="flex:1">
+<div style="font-size:26px;font-weight:800;color:#2FBF2F;margin-bottom:20px">TIPOGRAFÍA — fuente estándar de Switch · 5 tamaños</div>
+<div style="display:flex;flex-direction:column;gap:14px">
+<div style="display:flex;align-items:baseline;gap:20px"><b style="width:110px;font-family:'JetBrains Mono',monospace;color:#98A2B3">XS · 24px</b><span style="font-size:24px">Hints de botones, captions, rutas de log</span></div>
+<div style="display:flex;align-items:baseline;gap:20px"><b style="width:110px;font-family:'JetBrains Mono',monospace;color:#98A2B3">S · 30px</b><span style="font-size:30px">Metadatos, notas, estados secundarios</span></div>
+<div style="display:flex;align-items:baseline;gap:20px"><b style="width:110px;font-family:'JetBrains Mono',monospace;color:#98A2B3">M · 38px</b><span style="font-size:38px">Cuerpo: tabs, filas de ajustes, mensajes</span></div>
+<div style="display:flex;align-items:baseline;gap:20px"><b style="width:110px;font-family:'JetBrains Mono',monospace;color:#98A2B3">L · 54px</b><span style="font-size:54px;font-weight:700">Títulos de pantalla y de juego</span></div>
+<div style="display:flex;align-items:baseline;gap:20px"><b style="width:110px;font-family:'JetBrains Mono',monospace;color:#98A2B3">XL · 100px</b><span style="font-size:100px;font-weight:800;line-height:1">Código · logo</span></div>
+</div>
+<div style="font-size:26px;font-weight:800;color:#2FBF2F;margin:36px 0 16px">ESPACIADO</div>
+<div style="font-size:20px;color:#98A2B3;line-height:1.9">Margen de seguridad: <b style="color:#F0F3F8">60px</b> en los 4 bordes (overscan TV) · Unidad base: <b style="color:#F0F3F8">8px</b> · Footer de hints: <b style="color:#F0F3F8">84px</b> de alto, borde superior 2px #1C2230 · Cabecera de biblioteca: filas a y=48 y y=124 · Parrilla: 6 col × 230×345px, gap-x 40, gap-y 72, origen x=170 y=220</div>
+</div>
+</div>
+<div style="display:flex;gap:60px;align-items:flex-start">
+<div>
+<div style="font-size:26px;font-weight:800;color:#2FBF2F;margin-bottom:20px">SISTEMA DE FOCO — visible a 3 m</div>
+<div style="display:flex;gap:48px;align-items:center">
+<div style="padding:40px">
+<div style="width:248px;height:372px;background:#233047;border:6px solid #2FBF2F;box-shadow:0 0 0 6px rgba(47,191,47,.4),0 0 0 14px rgba(47,191,47,.15);position:relative">
+<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">SD</div>
+</div>
+<div style="width:284px;margin:14px 0 0 -18px;background:#161B24;padding:10px 0;text-align:center;font-size:24px;font-weight:700">Starfall Drift</div>
+</div>
+<div style="font-size:20px;color:#98A2B3;line-height:2;max-width:640px">
+<b style="color:#F0F3F8">4 capas, todas con rects:</b><br>
+1 · <b style="color:#F0F3F8">Escala 1.08×</b>: la textura se dibuja 230×345 → 248×372, centrada (−9px x, −13px y).<br>
+2 · <b style="color:#F0F3F8">Borde</b>: frame() 6px, color kFocus #2FBF2F.<br>
+3 · <b style="color:#F0F3F8">Glow simulado</b>: 2 frames concéntricos — 6px a offset +6 con alpha 102 (40%), 8px a offset +14 con alpha 38 (15%). Alpha simple sobre fondo.<br>
+4 · <b style="color:#F0F3F8">Placa de nombre</b>: fill kSurface bajo la tarjeta (ancho tarjeta+36, alto 44), texto XS 24px bold centrado. Solo en el elemento enfocado.<br>
+<span style="color:#6b7484">Transición: el borde+glow interpolan alpha 0→100% en 120 ms (2 valores de alpha por frame, coste cero).</span>
+</div>
+</div>
+</div>
+<div>
+<div style="font-size:26px;font-weight:800;color:#2FBF2F;margin-bottom:20px">CHIPS DE BOTONES (footer)</div>
+<div style="display:flex;align-items:center;gap:36px;background:#0E1118;border-top:2px solid #1C2230;padding:22px 40px">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">A</span><span style="font-size:24px;color:#F0F3F8">Play</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Back</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZL</span><span style="font-size:24px;color:#98A2B3">Settings</span></span>
+</div>
+<div style="font-size:20px;color:#98A2B3;line-height:2;margin-top:16px;max-width:560px">Chip = fill 40×40 kSurfaceHi + frame 2px #2A3242 + letra XS bold centrada. La acción primaria de la pantalla usa fill kAccent y label kText. Separación entre hints: 36px. Alineados a la derecha, a 60px del borde.</div>
+</div>
+</div>
+</div></div>
+
+<!-- ============ 1b SPLASH ============ -->
+<div class="dv-opt" id="1b"><div class="dv-olabel"><a class="dv-oid" href="#1b">1b</a>Splash — animación de arranque (~1,2 s), fotograma final</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Splash">
+<div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:0">
+<div style="display:flex;align-items:center;gap:36px">
+<div style="width:120px;height:120px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:54px;font-weight:800;color:#fff">nx</div>
+<div style="font-size:100px;font-weight:800;letter-spacing:-2px">green-nx</div>
+</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:28px">Xbox Cloud Gaming for Nintendo Switch</div>
+<div style="width:360px;height:6px;background:#1C2230;margin-top:64px;position:relative"><div style="position:absolute;left:0;top:0;height:6px;width:238px;background:#2FBF2F"></div></div>
+</div>
+</div>
+<div class="dv-note"><b>Animación (3 fases, todo rects/alpha):</b> 0–300ms el cuadrado verde crece de 0×120 a 120×120 (anchura del fill por frame) · 300–600ms wordmark+subtítulo fade-in (alpha 0→255) · 600ms+ la barra de progreso (fill kBar 360×6 + fill kFocus de anchura = progreso real de arranque). Sin spinner: la barra ES el indicador. Primitivas: 2 fill, 1 fill animado, 3 text.</div></div>
+
+<!-- ============ 1c SIGN-IN ============ -->
+<div class="dv-opt" id="1c"><div class="dv-olabel"><a class="dv-oid" href="#1c">1c</a>Sign-in — el código es el protagonista, legible a 3 m</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Sign-in">
+<div style="position:absolute;left:60px;top:48px;display:flex;align-items:center;gap:20px">
+<div style="width:44px;height:44px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:800;color:#fff">nx</div>
+<div style="font-size:30px;font-weight:700">green-nx</div>
+</div>
+<div style="position:absolute;left:0;right:0;top:170px;display:flex;flex-direction:column;align-items:center">
+<div style="font-size:54px;font-weight:700">Sign in with Microsoft</div>
+<div style="display:flex;align-items:center;gap:24px;margin-top:64px">
+<div style="width:44px;height:44px;background:#161B24;border:2px solid #2A3242;display:flex;align-items:center;justify-content:center;font-size:24px;font-weight:700;color:#98A2B3;box-sizing:border-box">1</div>
+<div style="font-size:30px;color:#98A2B3">On your phone or computer, open</div>
+<div style="background:#161B24;padding:10px 28px;font-size:38px;font-weight:700;color:#2FBF2F">microsoft.com/link</div>
+</div>
+<div style="display:flex;align-items:center;gap:24px;margin-top:36px">
+<div style="width:44px;height:44px;background:#161B24;border:2px solid #2A3242;display:flex;align-items:center;justify-content:center;font-size:24px;font-weight:700;color:#98A2B3;box-sizing:border-box">2</div>
+<div style="font-size:30px;color:#98A2B3">and enter this code</div>
+</div>
+<div style="margin-top:44px;background:#161B24;border:4px solid #107C10;padding:36px 80px;display:flex;align-items:center;gap:48px">
+<div style="font-size:100px;font-weight:800;letter-spacing:14px;line-height:1">FJK3</div>
+<div style="width:24px;height:8px;background:#2A3242"></div>
+<div style="font-size:100px;font-weight:800;letter-spacing:14px;line-height:1">PZQ7</div>
+</div>
+<div style="display:flex;align-items:center;gap:16px;margin-top:56px">
+<div style="width:14px;height:14px;background:#F0F3F8"></div>
+<div style="width:14px;height:14px;background:rgba(240,243,248,.55)"></div>
+<div style="width:14px;height:14px;background:rgba(240,243,248,.25)"></div>
+<div style="font-size:24px;color:#98A2B3;margin-left:12px">Waiting for you to sign in…</div>
+</div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZL</span><span style="font-size:24px;color:#98A2B3">Settings · region bypass</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Exit</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Primitivas:</b> pasos = fill 44×44 kSurface + frame 2px + text; URL = fill kSurface + text M en kFocus; código = fill kSurface + frame 4px kAccent + text XL 100px con letter-spacing (dibujar carácter a carácter con avance fijo de 14px extra) + fill 24×8 como separador central; spinner = 3 fills 14×14 con alpha pulsante (ya existe gfx.spinner, reducir a 14px). El grupo 4+4 evita errores de lectura del código.</div></div>
+
+<!-- ============ 1d LOADING ============ -->
+<div class="dv-opt" id="1d"><div class="dv-olabel"><a class="dv-oid" href="#1d">1d</a>Carga de biblioteca — skeleton de la parrilla en lugar de texto suelto</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Loading library">
+<div style="position:absolute;left:60px;top:48px;display:flex;align-items:center;gap:20px">
+<div style="width:44px;height:44px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:800;color:#fff">nx</div>
+<div style="font-size:30px;font-weight:700">green-nx</div>
+</div>
+<div style="position:absolute;left:170px;top:124px;width:220px;height:38px;background:#161B24"></div>
+<div style="position:absolute;left:170px;top:220px;display:flex;gap:40px">
+<div style="width:230px;height:345px;background:#161B24"></div>
+<div style="width:230px;height:345px;background:#141821"></div>
+<div style="width:230px;height:345px;background:#12151d"></div>
+<div style="width:230px;height:345px;background:#101319"></div>
+<div style="width:230px;height:345px;background:#0E1116"></div>
+<div style="width:230px;height:345px;background:#0D0F14"></div>
+</div>
+<div style="position:absolute;left:0;right:0;top:700px;display:flex;flex-direction:column;align-items:center;gap:24px">
+<div style="display:flex;align-items:center;gap:16px">
+<div style="width:14px;height:14px;background:#F0F3F8"></div>
+<div style="width:14px;height:14px;background:rgba(240,243,248,.55)"></div>
+<div style="width:14px;height:14px;background:rgba(240,243,248,.25)"></div>
+</div>
+<div style="font-size:30px;color:#98A2B3">Loading your library…</div>
+
+</div>
+</div>
+<div class="dv-note"><b>Primitivas:</b> cabecera real (ya cargada) + 1 fila de 6 fills kSurface con brillo decreciente (6 colores fijos, sin gradiente: cada tarjeta un tono más oscuro — simula profundidad de carga) + spinner + text S de estado ("Fetching credentials…" → "Loading your library…" → "Resolving names and covers (142)…"). El skeleton comunica QUÉ está cargando y ancla la transición: al llegar los datos, las tarjetas reales aparecen en el mismo sitio.</div></div>
+
+<!-- ============ 1e LIBRARY ============ -->
+<div class="dv-opt" id="1e"><div class="dv-olabel"><a class="dv-oid" href="#1e">1e</a>Biblioteca — pestaña All, foco en "Starfall Drift" · selector de origen en cabecera</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Library">
+<div style="position:absolute;left:60px;top:48px;display:flex;align-items:center;gap:20px">
+<div style="width:44px;height:44px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:800;color:#fff">nx</div>
+<div style="font-size:30px;font-weight:700">green-nx</div>
+</div>
+<div style="position:absolute;right:60px;top:48px;display:flex;align-items:center;gap:28px">
+<div style="display:flex;align-items:center;gap:12px;background:#161B24;padding:8px 20px">
+<div style="width:12px;height:12px;background:#2FBF2F"></div>
+<div style="font-size:24px;color:#F0F3F8">xCloud</div>
+<div style="font-size:24px;color:#5b6474">·</div>
+<div style="font-size:24px;color:#98A2B3">1080p HQ</div>
+</div>
+<div style="font-size:24px;color:#98A2B3">SgtNugget</div>
+</div>
+<div style="position:absolute;left:170px;top:124px;display:flex;align-items:center;gap:44px">
+<span style="min-width:36px;height:36px;background:#1C2230;border:2px solid #2A3242;color:#98A2B3;font-weight:700;font-size:22px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">L</span>
+<div style="position:relative;padding-bottom:12px"><span style="font-size:38px;font-weight:700;color:#F0F3F8">All games</span><div style="position:absolute;left:0;right:0;bottom:0;height:5px;background:#107C10"></div></div>
+<span style="font-size:38px;color:#5b6474">Favorites</span>
+<span style="font-size:38px;color:#5b6474">History</span>
+<span style="min-width:36px;height:36px;background:#1C2230;border:2px solid #2A3242;color:#98A2B3;font-weight:700;font-size:22px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">R</span>
+</div>
+<div style="position:absolute;right:170px;top:138px;font-size:24px;color:#5b6474">142 games</div>
+<div style="position:absolute;left:170px;top:220px;display:grid;grid-template-columns:repeat(6,230px);grid-auto-rows:345px;column-gap:40px;row-gap:72px">
+<div style="position:relative;background:#233047;z-index:2;transform:scale(1.08);border:6px solid #2FBF2F;box-shadow:0 0 0 6px rgba(47,191,47,.4),0 0 0 14px rgba(47,191,47,.15);box-sizing:border-box">
+<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">SD</div>
+<div style="position:absolute;left:6px;top:6px;width:44px;height:44px;background:#F0B43C;display:flex;align-items:center;justify-content:center;font-size:26px;color:#0A0D12">★</div>
+<div style="position:absolute;left:-24px;right:-24px;top:359px;background:#161B24;padding:9px 0;text-align:center;font-size:24px;font-weight:700;color:#F0F3F8">Starfall Drift</div>
+</div>
+<div style="position:relative;background:#3A2430"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">NV</div></div>
+<div style="position:relative;background:#1F3A33"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">IH</div><div style="position:absolute;left:8px;top:8px;width:44px;height:44px;background:#F0B43C;display:flex;align-items:center;justify-content:center;font-size:26px;color:#0A0D12">★</div></div>
+<div style="position:relative;background:#3B3220"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">DR</div></div>
+<div style="position:relative;background:#2C2440"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">EM</div></div>
+<div style="position:relative;background:#402620"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">BC</div></div>
+<div style="position:relative;background:#20303F"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">SR</div></div>
+<div style="position:relative;background:#33202C"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">CW</div><div style="position:absolute;left:8px;top:8px;width:44px;height:44px;background:#F0B43C;display:flex;align-items:center;justify-content:center;font-size:26px;color:#0A0D12">★</div></div>
+<div style="position:relative;background:#24313A"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">VP</div></div>
+<div style="position:relative;background:#312A1E"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">DL</div></div>
+<div style="position:relative;background:#1E2C24"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">FG</div></div>
+<div style="position:relative;background:#2E2233"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:84px;font-weight:800;color:rgba(255,255,255,.14)">HT</div></div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:32px;padding:0 60px;box-sizing:border-box;z-index:3">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">A</span><span style="font-size:24px;color:#F0F3F8">Details</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">X</span><span style="font-size:24px;color:#98A2B3">Favorite</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">Y</span><span style="font-size:24px;color:#98A2B3">Search</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZR</span><span style="font-size:24px;color:#98A2B3">Refresh</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZL</span><span style="font-size:24px;color:#98A2B3">Settings</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">−</span><span style="font-size:24px;color:#98A2B3">Sign out</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">+</span><span style="font-size:24px;color:#98A2B3">Exit</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Jerarquía resuelta:</b> fila 1 = identidad (logo) e identidad de sesión (origen + calidad + gamertag, agrupados en un chip kSurface); fila 2 = navegación (tabs con chips L/R pegados a ellas — el hint vive donde actúa) + contador degradado a #5b6474. <b>Selector de origen:</b> el chip "▪ xCloud · 1080p HQ" solo se dibuja si hay una consola vinculada (caso mayoritario: ni aparece); es informativo aquí — se cambia en <a class="dv-oid" href="#1k">1k</a> o Ajustes. <b>Parrilla:</b> igual que hoy (6 col) pero 230×345, gap-y 72 para la placa de nombre. Favorito: fill 44×44 kWarn + text "★" (glifo U+2605 presente en la fuente Switch). <b>Primitivas por tarjeta:</b> 1 textura (o fill+text si no cargó) + [fill+text favorito] + foco (ver <a class="dv-oid" href="#1a">1a</a>).</div></div>
+
+<!-- ============ 1f GAME DETAIL ============ -->
+<div class="dv-opt" id="1f"><div class="dv-olabel"><a class="dv-oid" href="#1f">1f</a>Detalle de juego — nueva pantalla: A abre esto, Play enfocado por defecto (un A extra lanza)</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Game detail">
+<div style="position:absolute;left:170px;top:120px;width:520px;height:780px;background:#233047">
+<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:160px;font-weight:800;color:rgba(255,255,255,.14)">SD</div>
+<div style="position:absolute;left:12px;top:12px;width:56px;height:56px;background:#F0B43C;display:flex;align-items:center;justify-content:center;font-size:32px;color:#0A0D12">★</div>
+</div>
+<div style="position:absolute;left:790px;top:150px;right:170px">
+<div style="font-size:54px;font-weight:700;line-height:1.2">Starfall Drift</div>
+<div style="display:flex;align-items:center;gap:20px;margin-top:24px">
+<div style="background:#161B24;padding:6px 18px;font-size:24px;color:#98A2B3">Xbox Cloud Gaming</div>
+<div style="background:#161B24;padding:6px 18px;font-size:24px;color:#98A2B3">1080p HQ</div>
+<div style="background:#161B24;padding:6px 18px;font-size:24px;color:#F0B43C">★ Favorite</div>
+</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:28px">Last played · yesterday</div>
+<div style="margin-top:64px;display:flex;flex-direction:column;gap:24px;width:640px">
+<div style="position:relative;background:#107C10;padding:26px 0;text-align:center;font-size:38px;font-weight:800;border:6px solid #2FBF2F;box-shadow:0 0 0 6px rgba(47,191,47,.4),0 0 0 14px rgba(47,191,47,.15);box-sizing:border-box">▶ Play</div>
+<div style="background:#161B24;padding:24px 0;text-align:center;font-size:38px;color:#F0F3F8">★ Remove favorite</div>
+<div style="background:#161B24;padding:24px 0;text-align:center;font-size:38px;color:#F0F3F8">Play on… <span style="color:#98A2B3">xCloud</span></div>
+</div>
+<div style="font-size:24px;color:#5b6474;margin-top:48px">Streams in your account's language · change in Settings</div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">A</span><span style="font-size:24px;color:#F0F3F8">Select</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Back</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Por qué detalle y no lanzamiento directo:</b> el coste es UN press extra de A (Play ya está enfocado al entrar: A-A lanza igual de rápido), y a cambo se gana espacio para favorito sin memorizar X, el selector de origen por-juego y sitio para el roadmap (logros, tiempo jugado). La misma textura de carátula se reutiliza escalada (520×780 = 2× la de parrilla; SDL escala texturas gratis). "Play on…" solo se dibuja con consola vinculada. <b>Primitivas:</b> textura + fills kSurface para chips/botones + foco estándar sobre el botón activo (borde 6 + 2 glow frames, sin escala en botones — solo cambia fill a kAccent).</div></div>
+
+<!-- ============ 1g SETTINGS ============ -->
+<div class="dv-opt" id="1g"><div class="dv-olabel"><a class="dv-oid" href="#1g">1g</a>Ajustes — foco de fila con barra lateral, valor con carets ‹ ›</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Settings">
+<div style="position:absolute;left:60px;top:48px;font-size:54px;font-weight:700">Settings</div>
+<div style="position:absolute;left:120px;top:170px;right:120px;display:flex;flex-direction:column;gap:18px">
+<div style="position:relative;height:96px;background:#212836;border:4px solid #2FBF2F;box-shadow:0 0 0 5px rgba(47,191,47,.35);display:flex;align-items:center;justify-content:space-between;padding:0 44px;box-sizing:border-box">
+<div style="position:absolute;left:0;top:0;bottom:0;width:10px;background:#2FBF2F"></div>
+<div style="font-size:38px;font-weight:700;margin-left:24px">Stream quality</div>
+<div style="display:flex;align-items:center;gap:28px"><span style="font-size:38px;color:#98A2B3">‹</span><span style="font-size:38px;color:#2FBF2F;font-weight:700">1080p high bitrate</span><span style="font-size:38px;color:#98A2B3">›</span></div>
+</div>
+<div style="height:96px;background:#161B24;display:flex;align-items:center;justify-content:space-between;padding:0 44px;box-sizing:border-box">
+<div style="font-size:38px;margin-left:24px;color:#F0F3F8">Button layout</div>
+<div style="font-size:38px;color:#107C10">Positional (Switch A = Xbox B)</div>
+</div>
+<div style="height:96px;background:#161B24;display:flex;align-items:center;justify-content:space-between;padding:0 44px;box-sizing:border-box">
+<div style="font-size:38px;margin-left:24px;color:#F0F3F8">Vibration</div>
+<div style="font-size:38px;color:#107C10">Medium</div>
+</div>
+<div style="height:96px;background:#161B24;display:flex;align-items:center;justify-content:space-between;padding:0 44px;box-sizing:border-box">
+<div style="font-size:38px;margin-left:24px;color:#F0F3F8">Region bypass</div>
+<div style="font-size:38px;color:#107C10">Off</div>
+</div>
+<div style="height:96px;background:#161B24;display:flex;align-items:center;justify-content:space-between;padding:0 44px;box-sizing:border-box">
+<div style="font-size:38px;margin-left:24px;color:#F0F3F8">Game language</div>
+<div style="font-size:38px;color:#107C10">English (US)</div>
+</div>
+</div>
+<div style="position:absolute;left:120px;right:120px;bottom:140px;background:#0E1118;border:2px solid #1C2230;padding:28px 44px;box-sizing:border-box;display:flex;gap:24px;align-items:flex-start">
+<div style="width:8px;height:64px;background:#107C10;flex:none"></div>
+<div style="font-size:30px;color:#98A2B3;line-height:1.6">Higher quality needs a stronger connection — 5 GHz Wi-Fi or docked LAN is recommended for 1080p high bitrate.</div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">◀ ▶</span><span style="font-size:24px;color:#98A2B3">Change</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Back</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Foco de fila</b> (variante para elementos anchos, donde escalar molesta): fill kSurfaceHi + barra lateral 10px kFocus + frame 4px kFocus + 1 glow frame 5px alpha 90 + valor en kFocus con carets ‹ › (U+2039/203A). Filas sin foco: fill kSurface, valor kAccent. <b>Nota contextual:</b> caja fija (no texto flotante): fill kBar + frame 2px + barra 8px kAccent + text S; cambia con la fila enfocada; usa kWarn en la barra cuando Region bypass ≠ Off. <b>Primitivas por fila:</b> 1–2 fill + 1 frame + 3 text.</div></div>
+
+<!-- ============ 1h STREAM CONNECTING ============ -->
+<div class="dv-opt" id="1h"><div class="dv-olabel"><a class="dv-oid" href="#1h">1h</a>Stream — conectando</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif;background:#000" data-screen-label="Stream connecting">
+<div style="position:absolute;left:0;right:0;top:300px;display:flex;flex-direction:column;align-items:center">
+<div style="width:160px;height:240px;background:#233047;position:relative"><div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:54px;font-weight:800;color:rgba(255,255,255,.14)">SD</div></div>
+<div style="font-size:54px;font-weight:700;margin-top:44px">Starfall Drift</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:16px">Negotiating connection…</div>
+<div style="width:560px;height:6px;background:#1C2230;margin-top:44px;position:relative"><div style="position:absolute;left:0;top:0;height:6px;width:336px;background:#2FBF2F"></div></div>
+<div style="display:flex;gap:32px;margin-top:20px;font-size:24px;color:#5b6474">
+<span style="color:#2FBF2F">Session</span><span style="color:#2FBF2F">ICE</span><span style="color:#F0F3F8">DTLS</span><span>Video</span>
+</div>
+</div>
+<div style="position:absolute;right:60px;top:48px;background:rgba(22,27,36,.85);padding:8px 20px;font-size:24px;color:#98A2B3">xCloud · 1080p HQ</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Cancel</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Fondo #000 puro</b> (el vídeo llegará sobre negro; evita un flash de color al hacer el handoff SDL→deko3d). La carátula ya está en memoria (misma textura de la parrilla, 160×240). <b>Barra de fases:</b> las 4 etapas reales del engine (Session/ICE/DTLS/Video) como text XS — completadas en kFocus, actual en kText, pendientes en #5b6474; la barra de progreso avanza ¼ por fase. Es honesto y diagnóstico: si se atasca, el usuario ve dónde. Al conectar: overlay 8 s "Hold − and + together to leave the stream" en banda inferior rgba(0,0,0,.6) + text XS (fill alpha + text, ya soportado).</div></div>
+
+<!-- ============ 1i STREAM FAILED ============ -->
+<div class="dv-opt" id="1i"><div class="dv-olabel"><a class="dv-oid" href="#1i">1i</a>Stream — fallo</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif;background:#000" data-screen-label="Stream failed">
+<div style="position:absolute;left:0;top:0;right:0;height:8px;background:#E86868"></div>
+<div style="position:absolute;left:460px;top:250px;width:1000px;background:#0E1118;border:2px solid #2A3242;box-sizing:border-box">
+<div style="display:flex;align-items:center;gap:24px;padding:36px 48px;border-bottom:2px solid #1C2230">
+<div style="width:56px;height:56px;background:#2A1416;border:3px solid #E86868;display:flex;align-items:center;justify-content:center;font-size:32px;font-weight:800;color:#E86868;box-sizing:border-box">!</div>
+<div style="font-size:54px;font-weight:700;color:#E86868">Stream failed</div>
+</div>
+<div style="padding:36px 48px">
+<div style="font-size:38px;line-height:1.5">The console lost connection to the streaming server (ICE timeout).</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:20px">Starfall Drift · after 12 min</div>
+<div style="margin-top:28px;background:#161B24;padding:14px 24px;font-size:24px;color:#98A2B3;font-family:'JetBrains Mono',monospace">log: /switch/green-nx/stream-log.txt</div>
+</div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">A</span><span style="font-size:24px;color:#F0F3F8">Retry</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Back to library</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Estructura en vez de texto suelto:</b> banda superior 8px kError (señal periférica inmediata) + tarjeta 1000px con cabecera (glifo "!" en caja 56×56: fill #2A1416 + frame 3px kError), cuerpo (mensaje M truncado a 2 líneas, contexto S dim) y ruta de log en caja kSurface. <b>Primitivas:</b> 5 fill + 3 frame + 6 text. El mismo esqueleto de tarjeta se reutiliza en <a class="dv-oid" href="#1j">1j</a>.</div></div>
+
+<!-- ============ 1j FATAL ============ -->
+<div class="dv-opt" id="1j"><div class="dv-olabel"><a class="dv-oid" href="#1j">1j</a>Error fatal — con sugerencia accionable (caso geo-gate)</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Fatal error">
+<div style="position:absolute;left:0;top:0;right:0;height:8px;background:#E86868"></div>
+<div style="position:absolute;left:410px;top:180px;width:1100px;background:#0E1118;border:2px solid #2A3242;box-sizing:border-box">
+<div style="display:flex;align-items:center;gap:24px;padding:36px 48px;border-bottom:2px solid #1C2230">
+<div style="width:56px;height:56px;background:#2A1416;border:3px solid #E86868;display:flex;align-items:center;justify-content:center;font-size:32px;font-weight:800;color:#E86868;box-sizing:border-box">!</div>
+<div style="font-size:54px;font-weight:700;color:#E86868">Something went wrong</div>
+</div>
+<div style="padding:36px 48px">
+<div style="font-size:38px;line-height:1.5">Streaming login failed: this account's region is not supported by Xbox Cloud Gaming (HTTP 403).</div>
+<div style="margin-top:32px;background:#161B24;border:2px solid #F0B43C;padding:28px 32px;display:flex;gap:24px;box-sizing:border-box">
+<div style="width:8px;background:#F0B43C;flex:none"></div>
+<div style="font-size:30px;color:#F0F3F8;line-height:1.6">Xbox Cloud Gaming may be unavailable in your region.<br><span style="color:#98A2B3">Press <b style="color:#F0F3F8">ZL</b> to open Settings, turn on <b style="color:#F0F3F8">Region bypass</b>, then press <b style="color:#F0F3F8">X</b> to retry.</span></div>
+</div>
+</div>
+</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">X</span><span style="font-size:24px;color:#F0F3F8">Retry</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZL</span><span style="font-size:24px;color:#98A2B3">Settings</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">−</span><span style="font-size:24px;color:#98A2B3">Sign out</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">+</span><span style="font-size:24px;color:#98A2B3">Exit</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Misma tarjeta que <a class="dv-oid" href="#1i">1i</a></b> + caja de sugerencia (frame 2px kWarn + barra 8px kWarn) que solo se dibuja cuando el error contiene "streaming login". La acción primaria (X Retry) usa el chip verde. Mensajes largos: truncar a 2 líneas de 38px (~90 chars), el detalle completo va al log.</div></div>
+
+<!-- ============ 1k SOURCE PICKER ============ -->
+<div class="dv-opt" id="1k"><div class="dv-olabel"><a class="dv-oid" href="#1k">1k</a>Roadmap: "Play on" — pantalla previa, SOLO si hay consola vinculada</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Source picker">
+<div style="position:absolute;left:0;right:0;top:150px;text-align:center;font-size:54px;font-weight:700">Play Starfall Drift on…</div>
+<div style="position:absolute;left:0;right:0;top:300px;display:flex;justify-content:center;gap:56px">
+<div style="width:560px;background:#212836;border:6px solid #2FBF2F;box-shadow:0 0 0 6px rgba(47,191,47,.4),0 0 0 14px rgba(47,191,47,.15);box-sizing:border-box;padding:56px 48px">
+<div style="width:72px;height:72px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:40px;font-weight:800;color:#fff">☁</div>
+<div style="font-size:38px;font-weight:800;margin-top:36px">xCloud</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:12px;line-height:1.6">Play in the cloud.<br>No console needed.</div>
+<div style="display:flex;align-items:center;gap:12px;margin-top:40px"><div style="width:12px;height:12px;background:#2FBF2F"></div><div style="font-size:24px;color:#98A2B3">Ready · 1080p HQ</div></div>
+</div>
+<div style="width:560px;background:#161B24;box-sizing:border-box;padding:56px 48px">
+<div style="width:72px;height:72px;background:#1C2230;border:2px solid #2A3242;display:flex;align-items:center;justify-content:center;font-size:40px;font-weight:800;color:#98A2B3;box-sizing:border-box">⌂</div>
+<div style="font-size:38px;font-weight:800;margin-top:36px">Your Xbox</div>
+<div style="font-size:30px;color:#98A2B3;margin-top:12px;line-height:1.6">Remote play from<br>SERIES X · living room</div>
+<div style="display:flex;align-items:center;gap:12px;margin-top:40px"><div style="width:12px;height:12px;background:#2FBF2F"></div><div style="font-size:24px;color:#98A2B3">Online · local network</div></div>
+</div>
+</div>
+<div style="position:absolute;left:0;right:0;top:880px;text-align:center;font-size:24px;color:#5b6474">Hold A on either option to make it the default and skip this screen</div>
+<div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#107C10;color:#fff;font-weight:800;font-size:24px;display:inline-flex;align-items:center;justify-content:center">A</span><span style="font-size:24px;color:#F0F3F8">Play</span></span>
+<span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">B</span><span style="font-size:24px;color:#98A2B3">Back</span></span>
+</div>
+</div>
+<div class="dv-note"><b>Regla de visibilidad (protege el caso mayoritario):</b> sin consola vinculada esta pantalla NO existe — A lanza xCloud directo y el chip de cabecera de <a class="dv-oid" href="#1e">1e</a> tampoco se dibuja. Con consola vinculada aparece 1 vez; "hold A" fija el default (settings.json) y a partir de ahí se vuelve a lanzamiento directo, con el chip de cabecera como recordatorio + fila nueva en Ajustes ("Preferred source") para cambiarlo. Iconos ☁ (U+2601) y ⌂ (U+2302): glifos Unicode de la fuente; si faltan, textura 72×72 pre-renderizada.</div></div>
+
+<!-- ============ 1l EMPTY ============ -->
+<div class="dv-opt" id="1l"><div class="dv-olabel"><a class="dv-oid" href="#1l">1l</a>Estado vacío — Favorites (mismo patrón para History y búsqueda)</div>
+<div class="dv-card" style="width:1920px;height:1080px;position:relative;overflow:hidden;color:#F0F3F8;font-family:'M PLUS 1p',sans-serif" data-screen-label="Empty favorites">
+<div style="position:absolute;left:60px;top:48px;display:flex;align-items:center;gap:20px">
+<div style="width:44px;height:44px;background:#107C10;display:flex;align-items:center;justify-content:center;font-size:22px;font-weight:800;color:#fff">nx</div>
+<div style="font-size:30px;font-weight:700">green-nx</div>
+</div>
+<div style="position:absolute;right:60px;top:48px;font-size:24px;color:#98A2B3">SgtNugget</div>
+<div style="position:absolute;left:170px;top:124px;display:flex;align-items:center;gap:44px">
+<span style="min-width:36px;height:36px;background:#1C2230;border:2px solid #2A3242;color:#98A2B3;font-weight:700;font-size:22px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">L</span>
+<span style="font-size:38px;color:#5b6474">All games</span>
+<div style="position:relative;padding-bottom:12px"><span style="font-size:38px;font-weight:700;color:#F0F3F8">Favorites</span><div style="position:absolute;left:0;right:0;bottom:0;height:5px;background:#107C10"></div></div>
+<span style="font-size:38px;color:#5b6474">History</span>
+<span style="min-width:36px;height:36px;background:#1C2230;border:2px solid #2A3242;color:#98A2B3;font-weight:700;font-size:22px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">R</span>
+</div>
+<div style="position:absolute;left:0;right:0;top:380px;display:flex;flex-direction:column;align-items:center">
+<div style="width:120px;height:120px;background:#161B24;display:flex;align-items:center;justify-content:center;font-size:64px;color:#F0B43C">★</div>
+<div style="font-size:38px;font-weight:700;margin-top:40px">No favorites yet</div>
+    <div style="display:flex;align-items:center;gap:14px;margin-top:20px">
+      <span style="font-size:30px;color:#98A2B3">Press</span>
+      <span style="width:36px;height:36px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:22px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">X</span>
+      <span style="font-size:30px;color:#98A2B3">on any game to pin it here</span>
+    </div>
+  </div>
+  <div style="position:absolute;left:0;right:0;bottom:0;height:84px;background:#0E1118;border-top:2px solid #1C2230;display:flex;align-items:center;justify-content:flex-end;gap:36px;padding:0 60px;box-sizing:border-box">
+    <span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">L R</span><span style="font-size:24px;color:#98A2B3">Tabs</span></span>
+    <span style="display:inline-flex;align-items:center;gap:12px"><span style="min-width:40px;height:40px;padding:0 8px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">ZL</span><span style="font-size:24px;color:#98A2B3">Settings</span></span>
+    <span style="display:inline-flex;align-items:center;gap:12px"><span style="width:40px;height:40px;background:#1C2230;border:2px solid #2A3242;color:#F0F3F8;font-weight:700;font-size:24px;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box">+</span><span style="font-size:24px;color:#98A2B3">Exit</span></span>
+  </div>
+</div>
+<div class="dv-note"><b>Patrón:</b> glifo grande en caja 120×120 kSurface (★ favoritos / ⌚ o texto "…" history / sin caja en búsqueda) + título M bold + instrucción S con el chip del botón embebido en la línea. Variantes: History → "Nothing played yet — games you launch appear here"; búsqueda → «Nothing found for "halo"» + hint Y. El footer omite A/X/Y (no hay tarjetas sobre las que actuar).</div></div>
+
+</div>
+<p style="margin:28px 0 0;font:13px/1.6 'M PLUS 1p',sans-serif;color:rgba(255,255,255,.45)">Siguientes pasos: "haz una variante gamer de <a class="dv-oid" href="#1e">1e</a> con el verde más protagonista" · "enséñame el overlay del hint de salida sobre vídeo" · "exporta la spec como documento imprimible"</p>
+</section>
+
+</x-dc>
+</body>
+</html>

--- a/src/switch/gfx.cpp
+++ b/src/switch/gfx.cpp
@@ -12,7 +12,7 @@
 namespace gnx::gfx {
 
 namespace {
-constexpr int kFontPx[5] = {26, 34, 52, 96, 40};
+constexpr int kFontPx[5] = {24, 38, 54, 100, 30};
 }
 
 bool Gfx::init() {
@@ -183,10 +183,11 @@ void Gfx::draw_texture(SDL_Texture* texture, const SDL_Rect& destination) {
 }
 
 void Gfx::spinner(int cx, int y, Uint32 ticks) {
+    // 3 pulsing 14x14 squares, 30px apart (redesign card 1c).
     for (int i = 0; i < 3; ++i) {
         float phase = std::sin((ticks / 200.0f) - i * 0.9f);
-        Uint8 alpha = static_cast<Uint8>(120 + 110 * (phase > 0 ? phase : 0));
-        SDL_Rect dot = {cx - 40 + i * 40, y, 16, 16};
+        Uint8 alpha = static_cast<Uint8>(64 + 191 * (phase > 0 ? phase : 0));
+        SDL_Rect dot = {cx - 37 + i * 30, y, 14, 14};
         fill(dot, {kText.r, kText.g, kText.b, alpha});
     }
 }

--- a/src/switch/gfx.hpp
+++ b/src/switch/gfx.hpp
@@ -16,18 +16,24 @@ struct Color {
     Uint8 r, g, b, a = 255;
 };
 
-// Palette
-constexpr Color kBg{16, 18, 24};
-constexpr Color kBgAccent{24, 28, 38};
-constexpr Color kCard{34, 39, 52};
-constexpr Color kCardFocus{16, 124, 16};  // Xbox green
-constexpr Color kText{235, 238, 245};
-constexpr Color kTextDim{150, 156, 170};
-constexpr Color kAccent{16, 124, 16};
-constexpr Color kWarn{240, 180, 60};
-constexpr Color kError{230, 90, 90};
+// Palette — "OLED premium" (docs-design/green-nx-redesign.dc.html, card 1a)
+constexpr Color kBg{10, 13, 18};          // #0A0D12 global background
+constexpr Color kBar{14, 17, 24};         // #0E1118 footer / header bands
+constexpr Color kSurface{22, 27, 36};     // #161B24 cards, rows, name plates
+constexpr Color kSurfaceHi{33, 40, 54};   // #212836 focused surface / chips
+constexpr Color kAccent{16, 124, 16};     // #107C10 brand, active tabs, values
+constexpr Color kFocus{47, 191, 47};      // #2FBF2F ONLY for the focus system
+constexpr Color kText{240, 243, 248};     // #F0F3F8 primary text
+constexpr Color kTextDim{152, 162, 179};  // #98A2B3 secondary text, hints
+constexpr Color kWarn{240, 180, 60};      // #F0B43C favorites, notices
+constexpr Color kError{232, 104, 104};    // #E86868 errors
+constexpr Color kChip{28, 34, 48};        // #1C2230 button chips, separators
+constexpr Color kChipEdge{42, 50, 66};    // #2A3242 chip border
+constexpr Color kFaint{91, 100, 116};     // #5b6474 tertiary (counters, idle tabs)
 
-enum class FontSize { Small = 0, Body, Title, Huge, Mono };
+// XS 24 hints/captions · Note(S) 30 metadata/status · Body(M) 38 tabs/rows ·
+// Title(L) 54 screen+game titles · Huge(XL) 100 sign-in code, logo.
+enum class FontSize { Small = 0, Body, Title, Huge, Note };
 
 class Gfx {
 public:

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -55,7 +55,7 @@ enum JoyButton {
 };
 
 enum class Scene {
-    Splash, SignIn, LoadingLibrary, Library, Settings, Stream, Fatal
+    Splash, SignIn, LoadingLibrary, Library, Detail, Settings, Stream, Fatal
 };
 
 enum class LibraryTab { All, Favorites, History };
@@ -178,6 +178,8 @@ struct App {
     Settings settings;
     int settings_cursor = 0;
     Scene settings_return = Scene::Library;  // scene to go back to from Settings
+    int detail_index = -1;   // games[] index shown in Scene::Detail
+    int detail_cursor = 0;   // 0 = Play, 1 = favorite toggle
 
 #ifdef GNX_NATIVE_STREAM
     std::unique_ptr<stream::Engine> engine;
@@ -465,166 +467,454 @@ std::string keyboard_input(const std::string& initial) {
 #endif
 }
 
-// ---- scenes ---------------------------------------------------------------
+// ---- scenes (layout per docs-design/green-nx-redesign.dc.html) ------------
 
-void draw_footer(App& app, const std::string& hints) {
-    app.gfx.fill({0, gfx::kHeight - 70, gfx::kWidth, 70}, gfx::kBgAccent);
-    app.gfx.text(hints, 60, gfx::kHeight - 55, gfx::FontSize::Small,
-                 gfx::kTextDim);
+constexpr int kMargin = 60;    // TV-safe margin on all edges
+constexpr int kFooterH = 84;
+constexpr int kFooterY = gfx::kHeight - kFooterH;
+
+// One footer hint: a button chip plus its label. The screen's primary action
+// gets the solid-accent chip.
+struct Hint {
+    const char* key;
+    const char* label;
+    bool primary = false;
+};
+
+// Chip = 40x40 fill (wider for multi-char keys) + 2px frame + centered glyph.
+int chip_width(App& app, const std::string& key) {
+    int tw = app.gfx.text_width(key, gfx::FontSize::Small);
+    return std::max(40, tw + 16);
+}
+
+void draw_chip(App& app, const std::string& key, int x, int y, bool primary) {
+    SDL_Rect box = {x, y, chip_width(app, key), 40};
+    app.gfx.fill(box, primary ? gfx::kAccent : gfx::kChip);
+    if (!primary) app.gfx.frame(box, gfx::kChipEdge, 2);
+    app.gfx.text_centered(key, box.x + box.w / 2, y + 4, gfx::FontSize::Small,
+                          primary ? gfx::kText : gfx::kText);
+}
+
+// Right-aligned hint row. with_bar draws the footer band behind it; screens
+// over video (stream) keep the background clear.
+void draw_hints(App& app, const std::vector<Hint>& hints,
+                bool with_bar = true) {
+    if (with_bar) {
+        app.gfx.fill({0, kFooterY, gfx::kWidth, kFooterH}, gfx::kBar);
+        app.gfx.fill({0, kFooterY, gfx::kWidth, 2}, gfx::kChip);
+    }
+    int x = gfx::kWidth - kMargin;
+    for (auto it = hints.rbegin(); it != hints.rend(); ++it) {
+        int lw = app.gfx.text_width(it->label, gfx::FontSize::Small);
+        int cw = chip_width(app, it->key);
+        x -= cw + 12 + lw;
+        int cy = kFooterY + (kFooterH - 40) / 2;
+        draw_chip(app, it->key, x, cy, it->primary);
+        app.gfx.text(it->label, x + cw + 12, cy + 4, gfx::FontSize::Small,
+                     it->primary ? gfx::kText : gfx::kTextDim);
+        x -= 32;
+    }
+}
+
+// Focus system, layer 2+3 of card 1a: 6px kFocus border + two concentric
+// "glow" frames (6px at +6 with 40% alpha, 8px at +14 with 15% alpha).
+void draw_focus_frames(App& app, const SDL_Rect& r) {
+    app.gfx.frame(r, gfx::kFocus, 6);
+    app.gfx.frame({r.x - 6, r.y - 6, r.w + 12, r.h + 12},
+                  {gfx::kFocus.r, gfx::kFocus.g, gfx::kFocus.b, 102}, 6);
+    app.gfx.frame({r.x - 14, r.y - 14, r.w + 28, r.h + 28},
+                  {gfx::kFocus.r, gfx::kFocus.g, gfx::kFocus.b, 38}, 8);
+}
+
+// Header: 44x44 accent square with "nx" + wordmark, top-left inside margins.
+void draw_header(App& app) {
+    SDL_Rect logo = {kMargin, 48, 44, 44};
+    app.gfx.fill(logo, gfx::kAccent);
+    app.gfx.text_centered("nx", logo.x + 22, logo.y + 6, gfx::FontSize::Small,
+                          gfx::kText);
+    app.gfx.text("green-nx", logo.x + 64, logo.y + 4, gfx::FontSize::Note,
+                 gfx::kText);
+}
+
+// Fallback cover: per-title dark hue + big translucent initials, so a grid
+// with covers still downloading reads as content instead of gray boxes.
+const gfx::Color kCoverHues[12] = {
+    {35, 48, 71},  {58, 36, 48},  {31, 58, 51},  {59, 50, 32},
+    {44, 36, 64},  {64, 38, 32},  {32, 48, 63},  {51, 32, 44},
+    {36, 49, 58},  {49, 42, 30},  {30, 44, 36},  {46, 34, 51}};
+
+gfx::Color cover_hue(const std::string& title_id) {
+    unsigned hash = 5381;
+    for (unsigned char c : title_id) hash = hash * 33 + c;
+    return kCoverHues[hash % 12];
+}
+
+std::string cover_initials(const Game& game) {
+    const std::string& name = game.name.empty() ? game.title_id : game.name;
+    std::string initials;
+    bool word_start = true;
+    for (char c : name) {
+        if (c == ' ') { word_start = true; continue; }
+        if (word_start && initials.size() < 2)
+            initials += static_cast<char>(std::toupper(c));
+        word_start = false;
+    }
+    return initials;
+}
+
+void draw_cover_fallback(App& app, const Game& game, const SDL_Rect& rect,
+                         gfx::FontSize initial_size) {
+    app.gfx.fill(rect, cover_hue(game.title_id));
+    app.gfx.text_centered(cover_initials(game), rect.x + rect.w / 2,
+                          rect.y + rect.h / 2 - 40, initial_size,
+                          {255, 255, 255, 36});
 }
 
 void draw_splash(App& app) {
-    Uint32 ticks = SDL_GetTicks();
-    app.gfx.text_centered("green-nx", gfx::kWidth / 2, 380,
-                          gfx::FontSize::Huge, gfx::kText);
-    app.gfx.text_centered("Xbox Cloud Gaming for Nintendo Switch",
-                          gfx::kWidth / 2, 510, gfx::FontSize::Body,
+    Uint32 elapsed = SDL_GetTicks() - app.scene_started;
+    int logo_w = static_cast<int>(120 * std::min(elapsed / 300.0f, 1.0f));
+    int word_w = app.gfx.text_width("green-nx", gfx::FontSize::Huge);
+    int row_w = 120 + 36 + word_w;
+    int x0 = (gfx::kWidth - row_w) / 2;
+    if (logo_w > 0) {
+        app.gfx.fill({x0, 400, logo_w, 120}, gfx::kAccent);
+        if (logo_w == 120)
+            app.gfx.text_centered("nx", x0 + 60, 428, gfx::FontSize::Title,
+                                  gfx::kText);
+    }
+    if (elapsed > 300) {
+        app.gfx.text("green-nx", x0 + 156, 408, gfx::FontSize::Huge,
+                     gfx::kText);
+        app.gfx.text_centered("Xbox Cloud Gaming for Nintendo Switch",
+                              gfx::kWidth / 2, 548, gfx::FontSize::Note,
+                              gfx::kTextDim);
+    }
+    // The bar IS the boot indicator: no spinner (card 1b).
+    SDL_Rect track = {gfx::kWidth / 2 - 180, 648, 360, 6};
+    app.gfx.fill(track, gfx::kChip);
+    int progress = static_cast<int>(360 * std::min(elapsed / 1200.0f, 1.0f));
+    app.gfx.fill({track.x, track.y, progress, 6}, gfx::kFocus);
+}
+
+// Numbered step bullet used by the sign-in screen.
+void draw_step_box(App& app, const char* number, int x, int y) {
+    SDL_Rect box = {x, y, 44, 44};
+    app.gfx.fill(box, gfx::kSurface);
+    app.gfx.frame(box, gfx::kChipEdge, 2);
+    app.gfx.text_centered(number, x + 22, y + 6, gfx::FontSize::Small,
                           gfx::kTextDim);
-    app.gfx.fill({gfx::kWidth / 2 - 120, 350, 240, 6}, gfx::kAccent);
-    app.gfx.spinner(gfx::kWidth / 2, 640, ticks);
+}
+
+// The device code split in two groups of glyphs drawn with a fixed 14px
+// extra advance (readable at 3 m, card 1c).
+int spaced_code_width(App& app, const std::string& group) {
+    int w = 0;
+    for (char c : group)
+        w += app.gfx.text_width(std::string(1, c), gfx::FontSize::Huge) + 14;
+    return w > 0 ? w - 14 : 0;
+}
+
+int draw_spaced_code(App& app, const std::string& group, int x, int y) {
+    for (char c : group) {
+        x += app.gfx.text(std::string(1, c), x, y, gfx::FontSize::Huge,
+                          gfx::kText) + 14;
+    }
+    return x;
 }
 
 void draw_signin(App& app) {
-    app.gfx.text_centered("Sign in with Microsoft", gfx::kWidth / 2, 180,
+    draw_header(app);
+    app.gfx.text_centered("Sign in with Microsoft", gfx::kWidth / 2, 170,
                           gfx::FontSize::Title, gfx::kText);
     if (app.device_code.user_code.empty()) {
         app.gfx.spinner(gfx::kWidth / 2, 480, SDL_GetTicks());
+        draw_hints(app, {{"B", "Exit"}});
         return;
     }
-    app.gfx.text_centered("On your phone or computer, open",
-                          gfx::kWidth / 2, 330, gfx::FontSize::Body,
-                          gfx::kTextDim);
-    app.gfx.text_centered(app.device_code.verification_uri, gfx::kWidth / 2,
-                          390, gfx::FontSize::Title, gfx::kText);
-    app.gfx.text_centered("and enter this code", gfx::kWidth / 2, 500,
-                          gfx::FontSize::Body, gfx::kTextDim);
 
-    int code_width = app.gfx.text_width(app.device_code.user_code,
-                                        gfx::FontSize::Huge);
-    SDL_Rect box = {gfx::kWidth / 2 - code_width / 2 - 50, 560,
-                    code_width + 100, 150};
-    app.gfx.fill(box, gfx::kCard);
+    // Step 1: box + text + URL chip, centered as one row.
+    const std::string& uri = app.device_code.verification_uri;
+    int uri_w = app.gfx.text_width(uri, gfx::FontSize::Body) + 56;
+    int t1_w = app.gfx.text_width("On your phone or computer, open",
+                                  gfx::FontSize::Note);
+    int row1_w = 44 + 24 + t1_w + 24 + uri_w;
+    int x = (gfx::kWidth - row1_w) / 2;
+    draw_step_box(app, "1", x, 300);
+    app.gfx.text("On your phone or computer, open", x + 68, 306,
+                 gfx::FontSize::Note, gfx::kTextDim);
+    SDL_Rect uri_box = {x + 68 + t1_w + 24, 292, uri_w, 62};
+    app.gfx.fill(uri_box, gfx::kSurface);
+    app.gfx.text_centered(uri, uri_box.x + uri_box.w / 2, 300,
+                          gfx::FontSize::Body, gfx::kFocus);
+
+    // Step 2.
+    int t2_w = app.gfx.text_width("and enter this code", gfx::FontSize::Note);
+    x = (gfx::kWidth - (44 + 24 + t2_w)) / 2;
+    draw_step_box(app, "2", x, 392);
+    app.gfx.text("and enter this code", x + 68, 398, gfx::FontSize::Note,
+                 gfx::kTextDim);
+
+    // The code, split 4+4 (or at the dash) to avoid read errors.
+    std::string code = app.device_code.user_code;
+    std::string left = code, right;
+    size_t dash = code.find('-');
+    if (dash != std::string::npos) {
+        left = code.substr(0, dash);
+        right = code.substr(dash + 1);
+    } else if (code.size() > 4) {
+        left = code.substr(0, code.size() / 2);
+        right = code.substr(code.size() / 2);
+    }
+    int lw = spaced_code_width(app, left);
+    int rw = spaced_code_width(app, right);
+    int inner = lw + (right.empty() ? 0 : 48 + 24 + 48 + rw);
+    SDL_Rect box = {(gfx::kWidth - (inner + 160)) / 2, 480, inner + 160, 190};
+    app.gfx.fill(box, gfx::kSurface);
     app.gfx.frame(box, gfx::kAccent, 4);
-    app.gfx.text_centered(app.device_code.user_code, gfx::kWidth / 2, 585,
-                          gfx::FontSize::Huge, gfx::kText);
-    app.gfx.spinner(gfx::kWidth / 2, 780, SDL_GetTicks());
-    draw_footer(app, "Waiting for sign-in...   ZL  Settings   B  Exit");
+    int cx = box.x + 80;
+    cx = draw_spaced_code(app, left, cx, box.y + 34);
+    if (!right.empty()) {
+        app.gfx.fill({cx + 48, box.y + box.h / 2 - 4, 24, 8}, gfx::kChipEdge);
+        draw_spaced_code(app, right, cx + 48 + 24 + 48, box.y + 34);
+    }
+
+    app.gfx.spinner(gfx::kWidth / 2 - 140, 736, SDL_GetTicks());
+    app.gfx.text("Waiting for you to sign in…", gfx::kWidth / 2 - 90, 728,
+                 gfx::FontSize::Small, gfx::kTextDim);
+    draw_hints(app, {{"ZL", "Settings · region bypass"}, {"B", "Exit"}});
 }
 
-void draw_loading(App& app) {
-    app.gfx.text_centered("green-nx", gfx::kWidth / 2, 380,
-                          gfx::FontSize::Huge, gfx::kText);
-    app.gfx.text_centered(app.status, gfx::kWidth / 2, 560,
-                          gfx::FontSize::Body, gfx::kTextDim);
-    app.gfx.spinner(gfx::kWidth / 2, 640, SDL_GetTicks());
-}
-
-// Grid geometry
+// Grid geometry (card 1e): 6 columns of 230x345 covers from (170,220),
+// 40px column gap, 72px row gap (room for the focused card's name plate).
 constexpr int kColumns = 6;
-constexpr int kCardW = 260;
-constexpr int kCardH = 390;
-constexpr int kGapX = 34;
-constexpr int kGapY = 88;
-constexpr int kGridX = (gfx::kWidth - kColumns * kCardW -
-                        (kColumns - 1) * kGapX) / 2;
-constexpr int kGridY = 150;
+constexpr int kCardW = 230;
+constexpr int kCardH = 345;
+constexpr int kGapX = 40;
+constexpr int kGapY = 72;
+constexpr int kGridX = 170;
+constexpr int kGridY = 220;
 constexpr int kRowsVisible = 2;
 
 const char* kTabNames[kTabCount] = {"All games", "Favorites", "History"};
-
-void draw_library(App& app) {
-    // Header: title, tab bar, gamertag, count/search.
-    app.gfx.text("green-nx", 60, 40, gfx::FontSize::Title, gfx::kText);
-    if (!app.gamertag.empty())
-        app.gfx.text(app.gamertag,
-                     gfx::kWidth - 60 -
-                         app.gfx.text_width(app.gamertag,
-                                            gfx::FontSize::Body),
-                     50, gfx::FontSize::Body, gfx::kTextDim);
-
-    int tx = 60;
-    for (int t = 0; t < kTabCount; ++t) {
-        bool active = static_cast<int>(app.tab) == t;
-        int w = app.gfx.text(kTabNames[t], tx, 100, gfx::FontSize::Body,
-                             active ? gfx::kText : gfx::kTextDim);
-        if (active) app.gfx.fill({tx, 142, w, 4}, gfx::kAccent);
-        tx += w + 50;
-    }
-    std::string info = std::to_string(app.visible.size()) + " games";
-    if (!app.query.empty()) info += "   ·   \"" + app.query + "\"";
-    app.gfx.text(info,
-                 gfx::kWidth - 60 - app.gfx.text_width(info, gfx::FontSize::Small),
-                 112, gfx::FontSize::Small, gfx::kTextDim);
-
-    if (app.visible.empty()) {
-        std::string msg;
-        if (!app.query.empty())
-            msg = "Nothing found for \"" + app.query + "\"";
-        else if (app.tab == LibraryTab::Favorites)
-            msg = "No favorites yet - press X on a game to add it";
-        else if (app.tab == LibraryTab::History)
-            msg = "Nothing played yet - your recent games will appear here";
-        else
-            msg = "No games available for this account";
-        app.gfx.text_centered(msg, gfx::kWidth / 2, 480, gfx::FontSize::Body,
-                              gfx::kTextDim);
-    }
-
-    int first_row = std::max(0, app.cursor / kColumns - (kRowsVisible - 1));
-    for (int slot = 0; slot < kColumns * (kRowsVisible + 1); ++slot) {
-        int index = first_row * kColumns + slot;
-        if (index >= static_cast<int>(app.visible.size())) break;
-        const Game& game = app.games[app.visible[index]];
-
-        int column = slot % kColumns;
-        int row = slot / kColumns;
-        SDL_Rect card = {kGridX + column * (kCardW + kGapX),
-                         kGridY + row * (kCardH + kGapY), kCardW, kCardH};
-        if (card.y > gfx::kHeight - 80) break;
-
-        SDL_Texture* cover =
-            app.covers->get(game.title_id, game.box_art_url);
-        if (cover) {
-            app.gfx.draw_texture(cover, card);
-        } else {
-            app.gfx.fill(card, gfx::kCard);
-            const std::string& label =
-                game.name.empty() ? game.title_id : game.name;
-            app.gfx.text_centered(label.substr(0, 18), card.x + kCardW / 2,
-                                  card.y + kCardH / 2 - 20,
-                                  gfx::FontSize::Small, gfx::kTextDim);
-        }
-
-        // Favorite marker: a gold badge (with a star glyph on top) top-left.
-        // The badge alone reads as "marked" even if the font lacks the glyph.
-        if (is_favorite(app, game.title_id)) {
-            SDL_Rect badge = {card.x + 8, card.y + 8, 50, 50};
-            app.gfx.fill(badge, gfx::kWarn);
-            app.gfx.text_centered("★", badge.x + 25, badge.y + 4,
-                                  gfx::FontSize::Body, gfx::kBg);
-        }
-
-        if (index == app.cursor) {
-            app.gfx.frame(card, gfx::kCardFocus, 5);
-            const std::string& label =
-                game.name.empty() ? game.title_id : game.name;
-            app.gfx.text_centered(label.substr(0, 30), card.x + kCardW / 2,
-                                  card.y + kCardH + 14,
-                                  gfx::FontSize::Small, gfx::kText);
-        }
-    }
-
-    draw_footer(app,
-                "A  Play   X  Favorite   L/R  Tabs   Y  Search   "
-                "ZR  Refresh   ZL  Settings   -  Sign out   +  Exit");
-}
 
 const char* kQualityLabels[3] = {"720p", "1080p", "1080p high bitrate"};
 const char* kMappingLabels[2] = {"Positional (Switch A = Xbox B)",
                                  "Match labels (Switch A = Xbox A)"};
 
+// Skeleton shades: each card one step darker, hinting at content loading in.
+const gfx::Color kSkeleton[6] = {{22, 27, 36}, {20, 24, 33}, {18, 21, 29},
+                                 {16, 19, 25}, {14, 17, 22}, {13, 15, 20}};
+
+void draw_loading(App& app) {
+    draw_header(app);
+    app.gfx.fill({kGridX, 124, 220, 38}, gfx::kSurface);
+    for (int i = 0; i < 6; ++i)
+        app.gfx.fill({kGridX + i * (kCardW + kGapX), kGridY, kCardW, kCardH},
+                     kSkeleton[i]);
+    app.gfx.spinner(gfx::kWidth / 2, 700, SDL_GetTicks());
+    app.gfx.text_centered(app.status, gfx::kWidth / 2, 744,
+                          gfx::FontSize::Note, gfx::kTextDim);
+}
+
+// One library card. The focused card scales 1.08x (230x345 -> 248x372,
+// centered), gets border+glow and a name plate under it (card 1a layer 1+4).
+void draw_card(App& app, const Game& game, const SDL_Rect& card,
+               bool focused) {
+    SDL_Rect dst = card;
+    if (focused) dst = {card.x - 9, card.y - 13, kCardW + 18, kCardH + 27};
+
+    SDL_Texture* cover = app.covers->get(game.title_id, game.box_art_url);
+    if (cover)
+        app.gfx.draw_texture(cover, dst);
+    else
+        draw_cover_fallback(app, game, dst, gfx::FontSize::Huge);
+
+    if (is_favorite(app, game.title_id)) {
+        SDL_Rect badge = {dst.x + 8, dst.y + 8, 44, 44};
+        app.gfx.fill(badge, gfx::kWarn);
+        app.gfx.text_centered("★", badge.x + 22, badge.y + 6,
+                              gfx::FontSize::Small, gfx::kBg);
+    }
+
+    if (focused) {
+        draw_focus_frames(app, dst);
+        SDL_Rect plate = {card.x - 18, card.y + kCardH + 14, kCardW + 36, 44};
+        app.gfx.fill(plate, gfx::kSurface);
+        const std::string& label =
+            game.name.empty() ? game.title_id : game.name;
+        app.gfx.text_centered(label.substr(0, 24), plate.x + plate.w / 2,
+                              plate.y + 8, gfx::FontSize::Small, gfx::kText);
+    }
+}
+
+// Empty-state pattern (card 1l): big glyph box + title + instruction with
+// the relevant button chip embedded in the line.
+void draw_empty_state(App& app, const std::string& glyph, gfx::Color glyph_col,
+                      const std::string& title, const std::string& pre,
+                      const char* chip_key, const std::string& post) {
+    if (!glyph.empty()) {
+        SDL_Rect box = {gfx::kWidth / 2 - 60, 380, 120, 120};
+        app.gfx.fill(box, gfx::kSurface);
+        app.gfx.text_centered(glyph, box.x + 60, box.y + 28,
+                              gfx::FontSize::Title, glyph_col);
+    }
+    app.gfx.text_centered(title, gfx::kWidth / 2, 540, gfx::FontSize::Body,
+                          gfx::kText);
+    int pre_w = app.gfx.text_width(pre, gfx::FontSize::Note);
+    int post_w = app.gfx.text_width(post, gfx::FontSize::Note);
+    int cw = chip_key ? chip_width(app, chip_key) : 0;
+    int total = pre_w + (chip_key ? 14 + cw + 14 : 0) + post_w;
+    int x = (gfx::kWidth - total) / 2;
+    x += app.gfx.text(pre, x, 616, gfx::FontSize::Note, gfx::kTextDim);
+    if (chip_key) {
+        draw_chip(app, chip_key, x + 14, 612, false);
+        x += 14 + cw + 14;
+    }
+    app.gfx.text(post, x, 616, gfx::FontSize::Note, gfx::kTextDim);
+}
+
+void draw_library(App& app) {
+    // Row 1: identity (logo left, gamertag right).
+    draw_header(app);
+    if (!app.gamertag.empty())
+        app.gfx.text(app.gamertag,
+                     gfx::kWidth - kMargin -
+                         app.gfx.text_width(app.gamertag,
+                                            gfx::FontSize::Small),
+                     56, gfx::FontSize::Small, gfx::kTextDim);
+
+    // Row 2: navigation — L/R chips hugging the tabs (the hint lives where it
+    // acts), active tab kText + 5px accent underline, idle tabs kFaint.
+    int tx = kGridX;
+    draw_chip(app, "L", tx, 128, false);
+    tx += chip_width(app, "L") + 44;
+    for (int t = 0; t < kTabCount; ++t) {
+        bool active = static_cast<int>(app.tab) == t;
+        int w = app.gfx.text(kTabNames[t], tx, 124, gfx::FontSize::Body,
+                             active ? gfx::kText : gfx::kFaint);
+        if (active) app.gfx.fill({tx, 176, w, 5}, gfx::kAccent);
+        tx += w + 44;
+    }
+    draw_chip(app, "R", tx, 128, false);
+
+    std::string info = std::to_string(app.visible.size()) + " games";
+    if (!app.query.empty()) info += "  ·  \"" + app.query + "\"";
+    app.gfx.text(info,
+                 gfx::kWidth - kGridX -
+                     app.gfx.text_width(info, gfx::FontSize::Small),
+                 138, gfx::FontSize::Small, gfx::kFaint);
+
+    if (app.visible.empty()) {
+        if (!app.query.empty())
+            draw_empty_state(app, "", gfx::kText,
+                             "Nothing found for \"" + app.query + "\"",
+                             "Press", "Y", "to search again");
+        else if (app.tab == LibraryTab::Favorites)
+            draw_empty_state(app, "★", gfx::kWarn, "No favorites yet",
+                             "Press", "X", "on any game to pin it here");
+        else if (app.tab == LibraryTab::History)
+            draw_empty_state(app, "…", gfx::kTextDim, "Nothing played yet",
+                             "Games you launch appear here", nullptr, "");
+        else
+            draw_empty_state(app, "", gfx::kText,
+                             "No games available for this account",
+                             "Press", "ZR", "to refresh your library");
+    }
+
+    // Draw the focused card last so its scale/glow overlaps neighbours.
+    int first_row = std::max(0, app.cursor / kColumns - (kRowsVisible - 1));
+    int focused_slot = -1;
+    for (int slot = 0; slot < kColumns * (kRowsVisible + 1); ++slot) {
+        int index = first_row * kColumns + slot;
+        if (index >= static_cast<int>(app.visible.size())) break;
+        int column = slot % kColumns;
+        int row = slot / kColumns;
+        SDL_Rect card = {kGridX + column * (kCardW + kGapX),
+                         kGridY + row * (kCardH + kGapY), kCardW, kCardH};
+        if (card.y + 40 > kFooterY) break;
+        if (index == app.cursor) {
+            focused_slot = slot;
+            continue;
+        }
+        draw_card(app, app.games[app.visible[index]], card, false);
+    }
+    if (focused_slot >= 0) {
+        int column = focused_slot % kColumns;
+        int row = focused_slot / kColumns;
+        SDL_Rect card = {kGridX + column * (kCardW + kGapX),
+                         kGridY + row * (kCardH + kGapY), kCardW, kCardH};
+        draw_card(app, app.games[app.visible[app.cursor]], card, true);
+    }
+
+    draw_hints(app, {{"A", "Details", true},
+                     {"X", "Favorite"},
+                     {"Y", "Search"},
+                     {"ZR", "Refresh"},
+                     {"ZL", "Settings"},
+                     {"−", "Sign out"},
+                     {"+", "Exit"}});
+}
+
+// Game detail (card 1f): big cover left, title + meta chips + action buttons
+// right. Play is focused on entry, so A-A launches as fast as before.
+void draw_detail(App& app) {
+    if (app.detail_index < 0 ||
+        app.detail_index >= static_cast<int>(app.games.size()))
+        return;
+    const Game& game = app.games[app.detail_index];
+
+    SDL_Rect cover_rect = {kGridX, 120, 520, 780};
+    SDL_Texture* cover = app.covers->get(game.title_id, game.box_art_url);
+    if (cover)
+        app.gfx.draw_texture(cover, cover_rect);
+    else
+        draw_cover_fallback(app, game, cover_rect, gfx::FontSize::Huge);
+    bool fav = is_favorite(app, game.title_id);
+    if (fav) {
+        SDL_Rect badge = {cover_rect.x + 12, cover_rect.y + 12, 56, 56};
+        app.gfx.fill(badge, gfx::kWarn);
+        app.gfx.text_centered("★", badge.x + 28, badge.y + 10,
+                              gfx::FontSize::Body, gfx::kBg);
+    }
+
+    int rx = 790;
+    const std::string& title = game.name.empty() ? game.title_id : game.name;
+    app.gfx.text(title.substr(0, 34), rx, 150, gfx::FontSize::Title,
+                 gfx::kText);
+
+    // Meta chips: kSurface pills with XS text.
+    int cx2 = rx;
+    auto meta_chip = [&](const std::string& label, gfx::Color color) {
+        int w = app.gfx.text_width(label, gfx::FontSize::Small) + 36;
+        app.gfx.fill({cx2, 232, w, 44}, gfx::kSurface);
+        app.gfx.text(label, cx2 + 18, 238, gfx::FontSize::Small, color);
+        cx2 += w + 20;
+    };
+    meta_chip("Xbox Cloud Gaming", gfx::kTextDim);
+    meta_chip(kQualityLabels[app.settings.quality], gfx::kTextDim);
+    if (fav) meta_chip("★ Favorite", gfx::kWarn);
+
+    // Action buttons, 640 wide. Buttons don't scale on focus — only
+    // border+glow (and the primary keeps its accent fill).
+    const char* fav_label = fav ? "★ Remove favorite" : "★ Add favorite";
+    SDL_Rect play = {rx, 400, 640, 96};
+    app.gfx.fill(play, gfx::kAccent);
+    app.gfx.text_centered("Play", play.x + 320, play.y + 24,
+                          gfx::FontSize::Body, gfx::kText);
+    SDL_Rect favbtn = {rx, 520, 640, 96};
+    app.gfx.fill(favbtn, gfx::kSurface);
+    app.gfx.text_centered(fav_label, favbtn.x + 320, favbtn.y + 24,
+                          gfx::FontSize::Body, gfx::kText);
+    draw_focus_frames(app, app.detail_cursor == 0 ? play : favbtn);
+
+    app.gfx.text("Streams in your account's language · change in Settings",
+                 rx, 680, gfx::FontSize::Small, gfx::kFaint);
+
+    draw_hints(app, {{"A", "Select", true}, {"B", "Back"}});
+}
+
 void draw_settings(App& app) {
-    app.gfx.text("Settings", 60, 40, gfx::FontSize::Title, gfx::kText);
+    app.gfx.text("Settings", kMargin, 48, gfx::FontSize::Title, gfx::kText);
 
     struct Row {
         const char* title;
@@ -638,33 +928,73 @@ void draw_settings(App& app) {
         {"Game language", kLanguageLabels[app.settings.language]},
     };
     for (int i = 0; i < 5; ++i) {
-        SDL_Rect row = {120, 170 + i * 118, gfx::kWidth - 240, 94};
-        app.gfx.fill(row, gfx::kCard);
-        if (i == app.settings_cursor) app.gfx.frame(row, gfx::kCardFocus, 4);
-        app.gfx.text(rows[i].title, row.x + 40, row.y + 27,
+        SDL_Rect row = {120, 170 + i * 114, gfx::kWidth - 240, 96};
+        bool focused = i == app.settings_cursor;
+        // Row-focus variant (card 1g): wide elements don't scale — surface
+        // lift + 10px side bar + 4px border + one glow frame instead.
+        app.gfx.fill(row, focused ? gfx::kSurfaceHi : gfx::kSurface);
+        if (focused) {
+            app.gfx.fill({row.x, row.y, 10, row.h}, gfx::kFocus);
+            app.gfx.frame(row, gfx::kFocus, 4);
+            app.gfx.frame({row.x - 4, row.y - 4, row.w + 8, row.h + 8},
+                          {gfx::kFocus.r, gfx::kFocus.g, gfx::kFocus.b, 90},
+                          5);
+        }
+        app.gfx.text(rows[i].title, row.x + 68, row.y + 26,
                      gfx::FontSize::Body, gfx::kText);
-        app.gfx.text(rows[i].value,
-                     row.x + row.w - 40 -
-                         app.gfx.text_width(rows[i].value,
-                                            gfx::FontSize::Body),
-                     row.y + 27, gfx::FontSize::Body, gfx::kAccent);
+        int vw = app.gfx.text_width(rows[i].value, gfx::FontSize::Body);
+        if (focused) {
+            int vx = row.x + row.w - 44 - vw;
+            app.gfx.text("‹", vx - 56, row.y + 26, gfx::FontSize::Body,
+                         gfx::kTextDim);
+            app.gfx.text(rows[i].value, vx, row.y + 26, gfx::FontSize::Body,
+                         gfx::kFocus);
+            app.gfx.text("›", row.x + row.w - 44 + 20, row.y + 26,
+                         gfx::FontSize::Body, gfx::kTextDim);
+        } else {
+            app.gfx.text(rows[i].value, row.x + row.w - 44 - vw, row.y + 26,
+                         gfx::FontSize::Body, gfx::kAccent);
+        }
     }
-    const char* note;
-    if (app.settings_cursor == 4)
-        note =
-            "Sets the streamed console's language. Applies to games that have "
-            "no in-game language menu; takes effect on the next launch.";
-    else if (app.settings.region != 0)
-        note =
-            "Region bypass spoofs your location to Xbox to reach xCloud from "
-            "an unsupported country. Use your own account at your own risk.";
-    else
-        note =
-            "Higher quality needs a stronger connection - 5 GHz Wi-Fi or "
-            "docked LAN recommended for 1080p high bitrate";
-    app.gfx.text_centered(note, gfx::kWidth / 2, 800, gfx::FontSize::Small,
-                          gfx::kTextDim);
-    draw_footer(app, "Left / Right  Change   B  Back");
+
+    // Contextual note: a fixed structured box (fill kBar + frame + accent
+    // side bar), swapping content with the focused row. The bar turns kWarn
+    // while Region bypass is active.
+    const char* line1;
+    const char* line2;
+    switch (app.settings_cursor) {
+        case 1:
+            line1 = "Positional keeps the Switch layout under your thumbs;";
+            line2 = "match labels follows the printed A/B/X/Y letters.";
+            break;
+        case 2:
+            line1 = "Rumble intensity for the game's vibration effects.";
+            line2 = "High still leaves headroom to avoid the HD-rumble hum.";
+            break;
+        case 3:
+            line1 = "Region bypass spoofs your location to Xbox to reach";
+            line2 = "xCloud from an unsupported country. Use at your own risk.";
+            break;
+        case 4:
+            line1 = "Sets the streamed console's language for games without";
+            line2 = "an in-game language menu. Takes effect on next launch.";
+            break;
+        default:
+            line1 = "Higher quality needs a stronger connection — 5 GHz";
+            line2 = "Wi-Fi or docked LAN is recommended for high bitrate.";
+            break;
+    }
+    SDL_Rect note = {120, 820, gfx::kWidth - 240, 120};
+    app.gfx.fill(note, gfx::kBar);
+    app.gfx.frame(note, gfx::kChip, 2);
+    app.gfx.fill({note.x + 28, note.y + 28, 8, 64},
+                 app.settings.region != 0 ? gfx::kWarn : gfx::kAccent);
+    app.gfx.text(line1, note.x + 64, note.y + 20, gfx::FontSize::Note,
+                 gfx::kTextDim);
+    app.gfx.text(line2, note.x + 64, note.y + 60, gfx::FontSize::Note,
+                 gfx::kTextDim);
+
+    draw_hints(app, {{"◀ ▶", "Change"}, {"B", "Back"}});
 }
 
 #ifdef GNX_NATIVE_STREAM
@@ -737,19 +1067,82 @@ void apply_rumble(App& app) {
 #endif
 }
 
+// Shared error card (cards 1i/1j): top 8px error band + a boxed card with
+// an "!" glyph header, message body, and optional context/log lines.
+// Returns the y where extra content (suggestion box) may continue.
+int draw_error_card(App& app, const SDL_Rect& card, const char* title,
+                    const std::string& message, const std::string& context,
+                    bool show_log_path) {
+    app.gfx.fill({0, 0, gfx::kWidth, 8}, gfx::kError);
+    app.gfx.fill(card, gfx::kBar);
+    app.gfx.frame(card, gfx::kChipEdge, 2);
+
+    SDL_Rect icon = {card.x + 48, card.y + 36, 56, 56};
+    app.gfx.fill(icon, {42, 20, 22});
+    app.gfx.frame(icon, gfx::kError, 3);
+    app.gfx.text_centered("!", icon.x + 28, icon.y + 10, gfx::FontSize::Body,
+                          gfx::kError);
+    app.gfx.text(title, icon.x + 80, card.y + 34, gfx::FontSize::Title,
+                 gfx::kError);
+    app.gfx.fill({card.x, card.y + 128, card.w, 2}, gfx::kChip);
+
+    int y = card.y + 164;
+    app.gfx.text(message.substr(0, 60), card.x + 48, y, gfx::FontSize::Body,
+                 gfx::kText);
+    if (message.size() > 60) {
+        y += 52;
+        app.gfx.text(message.substr(60, 60), card.x + 48, y,
+                     gfx::FontSize::Body, gfx::kText);
+    }
+    y += 60;
+    if (!context.empty()) {
+        app.gfx.text(context, card.x + 48, y, gfx::FontSize::Note,
+                     gfx::kTextDim);
+        y += 52;
+    }
+    if (show_log_path) {
+        SDL_Rect log = {card.x + 48, y, card.w - 96, 56};
+        app.gfx.fill(log, gfx::kSurface);
+        app.gfx.text("log: /switch/green-nx/stream-log.txt", log.x + 24,
+                     log.y + 12, gfx::FontSize::Small, gfx::kTextDim);
+        y += 76;
+    }
+    return y;
+}
+
+// Map the engine's status line onto the 4 real connection stages shown under
+// the progress bar (card 1h).
+int stream_phase(const std::string& status) {
+    std::string s = lowercase(status);
+    if (s.find("video") != std::string::npos ||
+        s.find("frame") != std::string::npos)
+        return 3;
+    if (s.find("dtls") != std::string::npos ||
+        s.find("handshake") != std::string::npos ||
+        s.find("srtp") != std::string::npos)
+        return 2;
+    if (s.find("ice") != std::string::npos ||
+        s.find("candidate") != std::string::npos ||
+        s.find("connect") != std::string::npos)
+        return 1;
+    return 0;
+}
+
 void draw_stream(App& app, SDL_Joystick* joystick) {
     stream::EngineState state = app.engine->state();
 
+    // Pure black behind everything: the video arrives over black, so the
+    // SDL->deko3d handoff never flashes a colored frame.
+    app.gfx.fill({0, 0, gfx::kWidth, gfx::kHeight}, {0, 0, 0});
+
     if (state == stream::EngineState::Failed) {
-        app.gfx.text_centered("Stream failed", gfx::kWidth / 2, 360,
-                              gfx::FontSize::Title, gfx::kError);
-        app.gfx.text_centered(app.engine->error().substr(0, 90),
-                              gfx::kWidth / 2, 480, gfx::FontSize::Body,
-                              gfx::kText);
-        app.gfx.text_centered(
-            "Details: /switch/green-nx/stream-log.txt on your SD card",
-            gfx::kWidth / 2, 560, gfx::FontSize::Small, gfx::kTextDim);
-        draw_footer(app, "A  Retry   B  Back to library");
+        SDL_Rect card = {460, 250, 1000, 460};
+        draw_error_card(app, card, "Stream failed",
+                        app.engine->error(),
+                        app.launch_game.name.empty() ? app.launch_game.title_id
+                                                     : app.launch_game.name,
+                        true);
+        draw_hints(app, {{"A", "Retry", true}, {"B", "Back to library"}});
         return;
     }
 
@@ -773,42 +1166,90 @@ void draw_stream(App& app, SDL_Joystick* joystick) {
             read_gamepad(joystick, app.settings.mapping));
         apply_rumble(app);
 
-        if (SDL_GetTicks() < app.stream_hint_until)
+        if (SDL_GetTicks() < app.stream_hint_until) {
+            app.gfx.fill({0, kFooterY, gfx::kWidth, kFooterH},
+                         {0, 0, 0, 153});
             app.gfx.text_centered(
-                "Hold  -  and  +  together to leave the stream",
-                gfx::kWidth / 2, gfx::kHeight - 60, gfx::FontSize::Small,
+                "Hold  −  and  +  together to leave the stream",
+                gfx::kWidth / 2, gfx::kHeight - 62, gfx::FontSize::Small,
                 gfx::kTextDim);
+        }
         return;
     }
+
+    // Connecting (card 1h): the cover the user just chose, honest stage
+    // labels for the 4 real engine phases, and a bar that moves per phase.
+    SDL_Rect mini = {gfx::kWidth / 2 - 80, 300, 160, 240};
+    SDL_Texture* cover =
+        app.covers->get(app.launch_game.title_id, app.launch_game.box_art_url);
+    if (cover)
+        app.gfx.draw_texture(cover, mini);
+    else
+        draw_cover_fallback(app, app.launch_game, mini, gfx::FontSize::Title);
 
     const std::string& label =
         app.launch_game.name.empty() ? app.launch_game.title_id
                                      : app.launch_game.name;
-    app.gfx.text_centered(label, gfx::kWidth / 2, 400, gfx::FontSize::Title,
+    app.gfx.text_centered(label, gfx::kWidth / 2, 584, gfx::FontSize::Title,
                           gfx::kText);
-    app.gfx.text_centered(app.engine->status(), gfx::kWidth / 2, 520,
-                          gfx::FontSize::Body, gfx::kTextDim);
-    app.gfx.spinner(gfx::kWidth / 2, 620, SDL_GetTicks());
-    draw_footer(app, "B  Cancel");
+    app.gfx.text_centered(app.engine->status(), gfx::kWidth / 2, 664,
+                          gfx::FontSize::Note, gfx::kTextDim);
+
+    int phase = stream_phase(app.engine->status());
+    SDL_Rect track = {gfx::kWidth / 2 - 280, 736, 560, 6};
+    app.gfx.fill(track, gfx::kChip);
+    app.gfx.fill({track.x, track.y, 140 * (phase + 1), 6}, gfx::kFocus);
+
+    const char* stages[4] = {"Session", "ICE", "DTLS", "Video"};
+    int total = 0;
+    for (int i = 0; i < 4; ++i)
+        total += app.gfx.text_width(stages[i], gfx::FontSize::Small) + 32;
+    int sx = (gfx::kWidth - (total - 32)) / 2;
+    for (int i = 0; i < 4; ++i) {
+        gfx::Color color = i < phase ? gfx::kFocus
+                           : i == phase ? gfx::kText
+                                        : gfx::kFaint;
+        sx += app.gfx.text(stages[i], sx, 768, gfx::FontSize::Small, color) +
+              32;
+    }
+
+    // Quality chip, top right.
+    std::string quality =
+        std::string("xCloud · ") + kQualityLabels[app.settings.quality];
+    int qw = app.gfx.text_width(quality, gfx::FontSize::Small) + 40;
+    app.gfx.fill({gfx::kWidth - kMargin - qw, 48, qw, 44},
+                 {gfx::kSurface.r, gfx::kSurface.g, gfx::kSurface.b, 217});
+    app.gfx.text(quality, gfx::kWidth - kMargin - qw + 20, 54,
+                 gfx::FontSize::Small, gfx::kTextDim);
+
+    draw_hints(app, {{"B", "Cancel"}}, /*with_bar=*/false);
 }
 #endif
 
 void draw_fatal(App& app) {
-    app.gfx.text_centered("Something went wrong", gfx::kWidth / 2, 340,
-                          gfx::FontSize::Title, gfx::kError);
-    app.gfx.text_centered(app.fatal.substr(0, 90), gfx::kWidth / 2, 470,
-                          gfx::FontSize::Body, gfx::kText);
-    if (app.fatal.size() > 90)
-        app.gfx.text_centered(app.fatal.substr(90, 90), gfx::kWidth / 2, 520,
-                              gfx::FontSize::Body, gfx::kText);
-    // The streaming-login step is the geo gate; if it failed, point the user at
-    // the Region bypass setting rather than leaving them at a dead end.
-    if (app.fatal.find("streaming login") != std::string::npos)
-        app.gfx.text_centered(
-            "Xbox Cloud Gaming may be unavailable in your region. Press ZL for "
-            "Settings, turn on Region bypass, then press X to retry.",
-            gfx::kWidth / 2, 610, gfx::FontSize::Small, gfx::kTextDim);
-    draw_footer(app, "X  Retry   ZL  Settings   -  Sign out   +  Exit");
+    SDL_Rect card = {410, 180, 1100,
+                     app.fatal.find("streaming login") != std::string::npos
+                         ? 560
+                         : 400};
+    int y = draw_error_card(app, card, "Something went wrong", app.fatal, "",
+                            false);
+    // The streaming-login step is the geo gate; if it failed, point the user
+    // at Region bypass instead of leaving a dead end (card 1j).
+    if (app.fatal.find("streaming login") != std::string::npos) {
+        SDL_Rect tip = {card.x + 48, y, card.w - 96, 150};
+        app.gfx.fill(tip, gfx::kSurface);
+        app.gfx.frame(tip, gfx::kWarn, 2);
+        app.gfx.fill({tip.x + 28, tip.y + 28, 8, 94}, gfx::kWarn);
+        app.gfx.text("Xbox Cloud Gaming may be unavailable in your region.",
+                     tip.x + 64, tip.y + 22, gfx::FontSize::Note, gfx::kText);
+        app.gfx.text("Press ZL for Settings, turn on Region bypass, then X.",
+                     tip.x + 64, tip.y + 74, gfx::FontSize::Note,
+                     gfx::kTextDim);
+    }
+    draw_hints(app, {{"X", "Retry", true},
+                     {"ZL", "Settings"},
+                     {"−", "Sign out"},
+                     {"+", "Exit"}});
 }
 
 // ---- input ----------------------------------------------------------------
@@ -1029,18 +1470,39 @@ int main(int argc, char** argv) {
                     app.scene = Scene::Settings;
                 }
                 if (input.a && !app.visible.empty()) {
-                    app.launch_game = app.games[app.visible[app.cursor]];
-                    push_history(app, app.launch_game.title_id);
-#ifdef GNX_NATIVE_STREAM
-                    app.engine->start(
-                        app.launch_game.title_id,
-                        static_cast<QualityTier>(app.settings.quality),
-                        kLanguageCodes[app.settings.language]);
-                    app.stream_hint_until = SDL_GetTicks() + 8000;
-                    app.scene = Scene::Stream;
-#endif
+                    // Card 1f: A opens the detail screen with Play focused,
+                    // so A-A still launches as fast as direct launch did.
+                    app.detail_index = app.visible[app.cursor];
+                    app.detail_cursor = 0;
+                    app.scene = Scene::Detail;
                 }
                 if (input.plus) running = false;
+                break;
+            }
+
+            case Scene::Detail: {
+                if (input.up) app.detail_cursor = 0;
+                if (input.down) app.detail_cursor = 1;
+                if (input.b) app.scene = Scene::Library;
+                if (input.a && app.detail_index >= 0 &&
+                    app.detail_index < static_cast<int>(app.games.size())) {
+                    const Game& game = app.games[app.detail_index];
+                    if (app.detail_cursor == 1) {
+                        toggle_favorite(app, game.title_id);
+                        apply_filter(app);
+                    } else {
+                        app.launch_game = game;
+                        push_history(app, app.launch_game.title_id);
+#ifdef GNX_NATIVE_STREAM
+                        app.engine->start(
+                            app.launch_game.title_id,
+                            static_cast<QualityTier>(app.settings.quality),
+                            kLanguageCodes[app.settings.language]);
+                        app.stream_hint_until = SDL_GetTicks() + 8000;
+                        app.scene = Scene::Stream;
+#endif
+                    }
+                }
                 break;
             }
 
@@ -1189,6 +1651,7 @@ int main(int argc, char** argv) {
             case Scene::SignIn: draw_signin(app); break;
             case Scene::LoadingLibrary: draw_loading(app); break;
             case Scene::Library: draw_library(app); break;
+            case Scene::Detail: draw_detail(app); break;
             case Scene::Settings: draw_settings(app); break;
             case Scene::Stream:
 #ifdef GNX_NATIVE_STREAM


### PR DESCRIPTION
Implements the "OLED premium" redesign proposed in #5.

Rebased on current `main` (1.0.14). Touches only `gfx.*`, `main.cpp`, and adds the design spec — no engine/streaming changes.

### What's in it

- **Design system in `gfx`**: 13-color OLED palette + a 24/30/38/54/100 type scale, replacing the old palette/sizes.
- **4-layer focus system** (visible at TV distance): 1.08× scale + 6px border + two simulated glow frames (alpha) + a name plate under the focused card.
- **Button-chip footer hints** with the screen's primary action highlighted.
- **Reworked screens**: animated splash with a real progress bar (no spinner); 4+4 giant sign-in code; library-skeleton loading; a cleaner library (identity row / navigation row with L/R chips hugging the tabs, per-title fallback covers); a new **game-detail** screen (A opens it with Play focused, so A-A launches as fast as before); row-focus settings with a structured contextual note; honest 4-stage stream connect (Session/ICE/DTLS/Video); a shared error card for stream-failed and fatal; and per-tab empty states.

### Design resource

Full spec + all 12 mockups as a single self-contained HTML file: [`docs-design/green-nx-redesign.dc.html`](https://github.com/luishidalgoa/green-nx/blob/feat/ui-redesign/docs-design/green-nx-redesign.dc.html) — every element is annotated with the exact primitives it uses.

### Notes

- Deliberately a proposal — happy to split screen-by-screen or drop anything you're not sold on.
- Running on real hardware (Switch OLED), holds 60fps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

