### PR TITLE
fix(audio): reset the jitter buffer between streams (intermittent no-audio)

### DIFF
--- a/src/switch/stream/audio_jitter.hpp
+++ b/src/switch/stream/audio_jitter.hpp
@@ -21,6 +21,18 @@ public:
     // false if we should wait for more. Call in a loop after each push().
     bool pop(std::vector<uint8_t>& out);
 
+    // Clear all state for reuse on a fresh RTP stream. The AudioPlayer is reused
+    // across streams (Engine owns it); without this the previous stream's
+    // next_seq_ persists, and since RTP randomizes the starting sequence number
+    // the RFC1982 "too late" test in push() can drop the ENTIRE new stream ->
+    // intermittent no-audio that only clears on reconnect. Call from init().
+    void reset() {
+        pending_.clear();
+        next_seq_ = 0;
+        have_next_ = false;
+        lost_ = 0;
+    }
+
     // Cumulative count of packets skipped as lost (a gap we gave up waiting on).
     uint32_t lost() const { return lost_; }
 

--- a/src/switch/stream/audio_player.cpp
+++ b/src/switch/stream/audio_player.cpp
@@ -50,6 +50,17 @@ bool AudioPlayer::init() {
     resample_pos_ = 0.0f;
     carry_[0] = carry_[1] = 0;
 
+    // AudioPlayer is reused across streams, so clear the per-session reorder
+    // buffer, inbox and counters. The reorder reset is the important one: a
+    // stale next_seq_ from the previous stream makes the RFC1982 "too late"
+    // check drop the whole new stream (intermittent no-audio until reconnect).
+    reorder_.reset();
+    inbox_.clear();
+    received_ = played_ = failed_ = lost_ = 0;
+    underruns_ = dropped_samples_ = frames_ = out_samples_ = 0;
+    adj_ppm_ = 0;
+    ema_ms_ = 0;
+
     if (R_FAILED(audoutInitialize())) return false;
     audout_up_ = true;
     if (R_FAILED(audoutStartAudioOut())) return false;


### PR DESCRIPTION
## Problem
Stream audio is intermittently silent: sometimes it plays, sometimes there is no sound at all until you exit and reconnect — roughly 50/50.

## Root cause
`Engine` owns an `AudioPlayer` and reuses it across streams, but `AudioPlayer::init()` reset the ring buffer and servo state — **not** the `AudioJitterBuffer`. Its `next_seq_` therefore persisted from the previous stream.

RTP randomizes the starting sequence number per stream, so when a new stream's first packet landed "before" the stale `next_seq_`, `AudioJitterBuffer::push()`'s RFC 1982 too-late check (`seq_before(seq, next_seq_)`) dropped **every** packet of the new stream. The decoder never received anything: `rx` kept climbing while `play` stayed frozen and the ring sat empty (`q=0ms`) — total silence. Whether it happened was ~50/50 by luck of the randomized start sequence, which matches the "sometimes no audio, re-entering fixes it" behaviour.

Observed in `stream-log.txt` on a failing session: `rx` 6885 → 8190 while `play` stuck at 5691, `in=0hz`, `q=0ms` (the stat counters were also carried over from the previous stream, confirming the reuse).

## Fix
Add `AudioJitterBuffer::reset()` and call it from `AudioPlayer::init()`, plus clear the inbox and stat counters, so every stream starts from a clean slate.

Tested on hardware (Switch / Atmosphère): the intermittent no-audio is gone across repeated exit → reconnect cycles.
