### PR TITLE
feat: "1080p low-latency" quality option (replaces "1080p high bitrate")

### DIFF
--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -135,7 +135,7 @@ struct SwitchRumble {
 #endif
 
 struct Settings {
-    int quality = 2;    // 0=720p, 1=1080p, 2=1080p HQ
+    int quality = 1;    // 0=720p, 1=1080p, 2=1080p low-latency
     int mapping = 0;    // 0=positional, 1=match labels
     int vibration = 2;  // rumble intensity: 0=Off, 1=Low, 2=Medium, 3=High
     int region = 0;     // region-bypass IP: 0=Off, else index into kRegion*
@@ -209,7 +209,7 @@ Settings load_settings() {
     if (!in) return settings;
     json data = json::parse(in, nullptr, false);
     if (data.is_discarded()) return settings;
-    settings.quality = std::clamp(data.value("quality", 2), 0, 2);
+    settings.quality = std::clamp(data.value("quality", 1), 0, 2);
     settings.mapping = std::clamp(data.value("mapping", 0), 0, 1);
     // "vibration" was an on/off bool before intensity levels existed; migrate.
     if (data.contains("vibration") && data["vibration"].is_boolean())
@@ -767,7 +767,7 @@ constexpr int kRowsVisible = 2;
 const char* kTabNames[kTabCount] = {"All games", "Favorites", "History",
                                     "Consoles"};
 
-const char* kQualityLabels[3] = {"720p", "1080p", "1080p high bitrate"};
+const char* kQualityLabels[3] = {"720p", "1080p", "1080p low-latency"};
 const char* kMappingLabels[2] = {"Positional (Switch A = Xbox B)",
                                  "Match labels (Switch A = Xbox A)"};
 
@@ -787,8 +787,12 @@ std::string console_label(const App& app) {
 void launch_stream(App& app, bool home) {
     app.launching_home = home && !app.consoles.empty();
 #ifdef GNX_NATIVE_STREAM
-    QualityTier tier = static_cast<QualityTier>(app.settings.quality);
+    // 720p / 1080p / "1080p low-latency": the last two both stream 1080p; the
+    // low-latency variant just flips the present pacing (no separate tier).
+    QualityTier tier = app.settings.quality == 0 ? QualityTier::P720
+                                                 : QualityTier::P1080;
     const char* locale = kLanguageCodes[app.settings.language];
+    app.engine->set_low_latency(app.settings.quality == 2);
     if (app.launching_home)
         app.engine->start_home(selected_console(app).server_id, tier, locale);
     else
@@ -1247,8 +1251,8 @@ void draw_settings(App& app) {
             line2 = "an in-game language menu. Takes effect on next launch.";
             break;
         default:
-            line1 = "Higher quality needs a stronger connection — 5 GHz";
-            line2 = "Wi-Fi or docked LAN is recommended for high bitrate.";
+            line1 = "720p or 1080p. \"1080p low-latency\" shows frames the";
+            line2 = "instant they decode: less lag, a touch less smooth.";
             break;
     }
     SDL_Rect note = {120, 820, gfx::kWidth - 240, 120};

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -990,6 +990,7 @@ void Engine::decode_loop() {
                 av_frame_ref(shared_frame_, video_.current_frame());
                 shared_frame_valid_ = true;
             }
+            frame_ready_.store(true, std::memory_order_relaxed);
             if (!got_frame_) {
                 got_frame_ = true;
                 state_ = EngineState::Streaming;
@@ -1019,7 +1020,15 @@ SDL_Texture* Engine::pump_video() {
     // producing without recycling the surface the GPU is still sampling.
     constexpr double kPresentIntervalMs = 1000.0 / 59.9;  // ~16.69 ms
     double now = static_cast<double>(SDL_GetTicks64());
-    if (dk_video_.initialized() && got_frame_ && now >= next_present_ms_) {
+    // Low-latency mode presents a freshly decoded frame immediately instead of
+    // waiting for the next steady tick (shaves up to ~1 frame of lag), but never
+    // faster than the panel -- deko3d aborts if we outrun the compositor. The
+    // trade is a slightly less even cadence (arrival jitter no longer smoothed).
+    bool due = low_latency_
+                   ? (frame_ready_.load(std::memory_order_relaxed) &&
+                      now - last_present_ms_ >= kPresentIntervalMs)
+                   : (now >= next_present_ms_);
+    if (dk_video_.initialized() && got_frame_ && due) {
         AVFrame* frame = nullptr;
         {
             std::lock_guard<std::mutex> lock(frame_mutex_);
@@ -1030,8 +1039,13 @@ SDL_Texture* Engine::pump_video() {
             }
         }
         if (frame) dk_video_.render(frame);
-        next_present_ms_ += kPresentIntervalMs;
-        if (next_present_ms_ < now) next_present_ms_ = now + kPresentIntervalMs;
+        if (low_latency_) {
+            frame_ready_.store(false, std::memory_order_relaxed);
+            last_present_ms_ = now;
+        } else {
+            next_present_ms_ += kPresentIntervalMs;
+            if (next_present_ms_ < now) next_present_ms_ = now + kPresentIntervalMs;
+        }
     }
     return nullptr;
 #else

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -53,6 +53,11 @@ public:
                     const std::string& locale = "en-US");
     void stop();
 
+    // Present a freshly decoded frame ASAP (rate-limited to the panel) instead
+    // of on the steady clock -- lower latency, slightly less smooth. Set before
+    // start(); default false.
+    void set_low_latency(bool enabled) { low_latency_ = enabled; }
+
     EngineState state() const { return state_; }
     std::string status() const;
     std::string error() const;
@@ -176,6 +181,9 @@ private:
     Uint64 stream_epoch_ = 0;
     // Render-thread software vsync pacer for the deko3d present (see pump_video).
     double next_present_ms_ = 0;
+    double last_present_ms_ = 0;            // low-latency mode: last present time
+    bool low_latency_ = false;              // present-on-decode vs steady clock
+    std::atomic<bool> frame_ready_{false};  // decode thread -> render: new frame
     std::atomic<Uint64> last_keyframe_req_{0};
     std::atomic<uint32_t> pli_sent_{0};  // RTCP PLI keyframe requests
 


### PR DESCRIPTION
Replaces the **"1080p high bitrate"** tier (which felt no different from plain 1080p) with **"1080p low-latency"**.

Both stream 1080p; picking low-latency flips the engine's present pacing to *present-on-decode* (rate-limited to the panel) instead of the steady software clock — about one frame less lag, at the cost of a slightly less even cadence. Default quality stays plain 1080p.

Scope: `src/switch/main.cpp` + the deko3d present pacer in `engine`. Builds clean from a fresh clone.
