### PR TITLE
fix(streaming): remove media-thread stalls and smooth frame cadence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ references/
 
 # Store-submission assets (kept local)
 promo/
+
+# Local safety snapshots (never include in release PRs)
+v2_safe/
+v1.0.19_safe/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 1.0.19
+
+- Added configurable endpoint-protected contrast enhancement.
+- Added independent three-second sharpening and contrast strobe comparisons.
+- Added non-overlapping, correctly oriented in-stream mode labels.
+- Expanded on-device guidance for image-enhancement settings.
+
+## 1.0.18
+
+- Added the sharpening strobe comparison and in-stream level label.
+
+## 1.0.17
+
+- Added configurable luma-only sharpening with Off, Low, Medium, High and
+  Extreme levels.
+
+## 1.0.16
+
+- Reset the audio jitter buffer and playback state between streams, fixing
+  missing audio after restarting a stream or switching pacing modes.
+
+## 1.0.15
+
+- Added Low latency and Smooth video-pacing modes.
+- Added separate logs for each pacing mode.
+- Added receive, decode, presentation and display-cadence diagnostics.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 
 APP_TITLE   := green-nx
 APP_AUTHOR  := rmrf404
-APP_VERSION := 1.0.14
+APP_VERSION := 1.0.19
 APP_ICON    := icon.jpg
 
 TARGET   := green-nx

--- a/README.md
+++ b/README.md
@@ -1,106 +1,153 @@
 # green-nx
 
-A standalone, open-source **Xbox Cloud Gaming (xCloud) client for the Nintendo
-Switch** (homebrew). Sign in with your Microsoft account and stream your Game
-Pass Ultimate library natively — WebRTC connection, hardware H.264 decoding and
-GPU rendering are all done on the console, with no companion apps or PCs
-involved.
+A standalone, open-source Xbox Cloud Gaming (xCloud) client for Nintendo
+Switch homebrew. Green NX signs in to Xbox, starts cloud games, receives the
+WebRTC stream, decodes H.264 in hardware, and renders it directly on the
+console. No companion PC or phone is required.
 
-**Fully working:** sign-in, game library with box art and search, and smooth
-720p / 1080p / 1080p HQ streaming with audio and full controller input.
+> [!NOTE]
+> Green NX is an experimental community project. It is not affiliated with,
+> endorsed by, or supported by Microsoft or Nintendo.
 
 ## Features
 
-- Microsoft **device-code sign-in** (no password typed on console); tokens
-  cached on SD
-- **Game library** with box-art covers, search, quality settings
-- **Native WebRTC streaming**: ICE (Teredo), DTLS-SRTP, SCTP data channels,
-  RTP video/audio, NACK/PLI recovery — implemented on-console
-- **Hardware H.264 decoding** (NVDEC via FFmpeg's NVTEGRA hwaccel) with
-  **zero-copy GPU rendering** (deko3d) — the decoded surface goes straight
-  from the decoder to the screen
-- Opus audio, 60 fps video, three quality tiers (720p / 1080p / 1080p HQ)
-
-## Requirements
-
-- A Nintendo Switch running the [Atmosphère](https://github.com/Atmosphere-NX/Atmosphere) custom firmware
-- An active **Xbox Game Pass Ultimate** subscription
-- A 5 GHz Wi-Fi connection is recommended
+- Microsoft device-code sign-in with cached tokens
+- Game Pass cloud library, cover art, search, region and language settings
+- Native WebRTC transport with ICE, DTLS-SRTP, SCTP, NACK/PLI recovery and REMB
+- NVTEGRA/NVDEC H.264 hardware decoding and deko3d zero-copy presentation
+- Opus audio and full controller input with configurable button mapping/rumble
+- 720p, 1080p and 1080p high-bitrate quality tiers
+- Low-latency and smooth video-pacing modes
+- GPU luma sharpening, contrast enhancement and labeled comparison tests
+- Per-pacing-mode diagnostic stream logs
 
 ## Install
 
-1. Copy `green-nx.nro` to `sdmc:/switch/` on your SD card.
-2. Launch **in title mode** — hold **R** while starting an installed game.
-   (Applet mode does not have enough memory for hardware video decoding.)
-3. Sign in once with the device code shown on screen (`microsoft.com/link`).
-   Tokens and the game list are cached in `sdmc:/switch/green-nx/`.
+Requirements:
 
-### Controls
+- A Nintendo Switch running
+  [Atmosphère](https://github.com/Atmosphere-NX/Atmosphere)
+- An Xbox Game Pass Ultimate subscription
+- 5 GHz Wi-Fi or docked Ethernet for the best results
+
+Copy `green-nx.nro` to `sdmc:/switch/`, then launch it in title mode by holding
+**R** while opening an installed game. Applet mode does not provide enough
+memory for hardware video decoding.
+
+Sign in using the device code displayed by the app. Tokens, settings, cached
+catalog data and stream logs are stored in `sdmc:/switch/green-nx/`.
+
+## Settings
+
+| Setting | Options | Guidance |
+| --- | --- | --- |
+| Stream quality | 720p, 1080p, 1080p high bitrate | Higher tiers require a stable, fast connection. |
+| Video pacing | Low latency, Smooth | Low latency presents the newest frame immediately. Smooth holds one decoded source frame to absorb arrival jitter, improving cadence at the cost of roughly one source frame of latency. |
+| Luma sharpening | Off, Low, Medium, High, Extreme, Strobe test | **Medium is recommended.** Sharpening affects brightness detail without sharpening chroma. Disable it if compression edges or halos become distracting. |
+| Contrast | Off, Low, Medium, High, Strobe test | **Medium is recommended.** The endpoint-protected curve improves perceived depth while retaining black and white endpoints. |
+| Button layout | Positional, Match labels | Select physical Xbox-style positions or matching printed Switch labels. |
+| Vibration | Off, Low, Medium, High | Controls rumble strength. |
+| Region bypass | Off plus available regions | Intended for unsupported xCloud locations; use at your own risk. |
+| Game language | Supported xCloud locales | Applied when the next game launches. |
+
+### Strobe tests
+
+Strobe is a visual comparison tool, not a normal playback mode. It changes the
+selected effect every three seconds and shows the active level in the top-left
+corner of the stream:
+
+- Sharpening cycles **Off → Low → Medium → High → Extreme**
+- Contrast cycles **Off → Low → Medium → High**
+
+Watch the same stationary detail and moving edges through a complete cycle,
+then select the fixed level you prefer. If both strobe tests are enabled, their
+labels use separate lines so they do not overlap.
+
+## Controls
 
 | Context | Buttons |
 | --- | --- |
-| Library | Left stick / d-pad move · **A** play · **Y** search · **X** refresh · **ZL** settings · **-** sign out · **+** exit |
-| Settings | Stream quality (720p / 1080p / 1080p HQ) · button layout (positional / labels) |
+| Library | Left stick/d-pad move · **A** play · **Y** search · **X** refresh · **ZL** settings · **-** sign out · **+** exit |
+| Settings | Up/down select · Left/right change · **B** or **ZL** back |
 | In stream | Xbox controls mapped from the Switch pad · hold **-** + **+** to quit |
+
+## Stream logs
+
+Each pacing mode writes a separate log so its timing can be analyzed without
+mixing behaviors:
+
+- `sdmc:/switch/green-nx/stream-log-low-latency.txt`
+- `sdmc:/switch/green-nx/stream-log-smooth.txt`
+
+The preceding session is retained with the matching `-prev` suffix. Timing and
+cadence records include receive, decode and presentation behavior. Logs can
+contain session diagnostics, so review them before sharing publicly.
+
+## Changes in this development version
+
+- Added a smooth pacing mode that uses a one-frame reserve to regularize
+  presentation cadence; low-latency mode preserves the original behavior.
+- Added independent logs for low-latency and smooth sessions.
+- Added decode, presentation and cadence diagnostics.
+- Fixed audio initialization when starting another stream or changing pacing
+  mode in the same app session.
+- Added configurable luma sharpening: Off, Low, Medium, High, Extreme and a
+  labeled three-second strobe comparison.
+- Added configurable endpoint-protected contrast enhancement: Off, Low,
+  Medium, High and a labeled three-second strobe comparison.
+- Kept sharpening and contrast strobe labels on separate overlay lines and
+  corrected their screen orientation.
+- Documented the recommended image settings and the latency/smoothness
+  tradeoff in the on-device Settings screen.
+
+See [CHANGELOG.md](CHANGELOG.md) for the concise release history.
 
 ## Build
 
-No local toolchain needed — everything builds inside the
-`devkitpro/devkita64` Docker image:
+Build with the `devkitpro/devkita64` Docker image:
 
 ```sh
-# 1. Build the WebRTC dependencies once (libpeer, libsrtp, usrsctp, mbedTLS)
+# Build the WebRTC dependencies once.
 bash deps/build-switch.sh
 
-# 2. Build the app
+# Build Green NX.
 docker run --rm -v "$PWD":/src -w /src devkitpro/devkita64 make
 ```
 
-The result is `green-nx.nro`. A small desktop harness
-(`make -f Makefile.pc`) builds the core (auth/catalog/signaling) for
-development on a PC.
+The output is `green-nx.nro`. The desktop harness can be built with
+`make -f Makefile.pc` for core auth, catalog and signaling development.
 
-### Layout
+### Source layout
 
-```
-src/core/            auth, catalog, HTTP, xCloud session + protocol
-src/switch/          UI (SDL2), covers, input
-src/switch/stream/   streaming engine: WebRTC glue, RTP jitter buffer,
-                     NVDEC decoder, deko3d zero-copy renderer, Opus audio
-shaders/             deko3d video shaders (compiled by uam during make)
-deps/                build script + patches for the WebRTC stack
+```text
+src/core/            Authentication, catalog, HTTP and xCloud protocol
+src/switch/          Switch UI, covers and input
+src/switch/stream/   WebRTC glue, jitter buffers, decoding, rendering and audio
+shaders/             deko3d video shaders, image enhancement and overlays
+deps/                WebRTC dependency build scripts and patches
 ```
 
 ## Third-party software
 
-green-nx builds on these open-source projects:
-
 | Project | License | Use |
 | --- | --- | --- |
-| [libpeer](https://github.com/sepfy/libpeer) (patched) | MIT | WebRTC: ICE / DTLS-SRTP / SCTP |
-| [libsrtp](https://github.com/cisco/libsrtp) | BSD-3 | SRTP encryption |
-| [usrsctp](https://github.com/sctplab/usrsctp) | BSD-3 | SCTP data channels |
-| [mbedTLS](https://github.com/Mbed-TLS/mbedtls) | Apache-2.0 | TLS / DTLS crypto |
-| [FFmpeg](https://ffmpeg.org) (devkitPro build with [averne's](https://github.com/averne/FFmpeg) NVTEGRA hwaccel) | LGPL-2.1+ | H.264 hardware decoding |
+| [libpeer](https://github.com/sepfy/libpeer) (patched) | MIT | WebRTC |
+| [libsrtp](https://github.com/cisco/libsrtp) | BSD-3-Clause | SRTP |
+| [usrsctp](https://github.com/sctplab/usrsctp) | BSD-3-Clause | SCTP |
+| [mbedTLS](https://github.com/Mbed-TLS/mbedtls) | Apache-2.0 | TLS/DTLS |
+| [FFmpeg](https://ffmpeg.org) with [NVTEGRA](https://github.com/averne/FFmpeg) | LGPL-2.1+ | H.264 decoding |
 | [deko3d](https://github.com/devkitPro/deko3d) | zlib | GPU rendering |
-| [SDL2](https://libsdl.org), SDL2_ttf, SDL2_image | zlib | UI rendering, input |
-| [Opus](https://opus-codec.org) | BSD-3 | Audio decoding |
+| [SDL2](https://libsdl.org), SDL2_ttf, SDL2_image | zlib | UI and input |
+| [Opus](https://opus-codec.org) | BSD-3-Clause | Audio |
 | [libcurl](https://curl.se) | curl | HTTPS |
 | [nlohmann/json](https://github.com/nlohmann/json) | MIT | JSON |
-| [devkitPro / libnx](https://devkitpro.org) | various | Switch toolchain and OS interface |
+| [devkitPro/libnx](https://devkitpro.org) | Various | Toolchain and Switch APIs |
 
-The patches applied to libpeer (keyframe requests, NACK, receiver reports,
-REMB, data-channel fixes, Switch port) are in `deps/patches/`.
-
-## Disclaimer
-
-green-nx is a **fun, experimental, non-commercial** hobby project, provided
-as-is for personal use. It is **not affiliated with, endorsed by, or supported
-by Microsoft or Nintendo** in any way. Xbox, Xbox Cloud Gaming and Game Pass
-are trademarks of Microsoft. Nintendo Switch is a trademark of Nintendo. You
-need your own valid Game Pass Ultimate subscription; this project only
-implements a client for a service you already pay for.
+The libpeer patches for keyframe requests, NACK, receiver reports, REMB, data
+channels and the Switch port are under `deps/patches/`.
 
 ## License
 
-[GPL-3.0](LICENSE)
+Green NX is provided as-is under [GPL-3.0](LICENSE). Xbox, Xbox Cloud Gaming
+and Game Pass are Microsoft trademarks. Nintendo Switch is a Nintendo
+trademark.

--- a/deps/build-switch.sh
+++ b/deps/build-switch.sh
@@ -75,9 +75,34 @@ if [[ "${1:-}" == "--inside" ]]; then
 
   # 5) Link smoke test: catches unresolved symbols early.
   echo "=== smoke test link"
-  cat > /tmp/smoketest.c <<'EOF'
+cat > /tmp/smoketest.c <<'EOF'
+#include <stdarg.h>
+#include <stddef.h>
+#include <switch.h>
 #include <peer.h>
 #include <peer_connection.h>
+
+/* The application supplies these platform hooks in switch_compat.c. Keep
+ * minimal definitions in the archive smoke test so it tests the dependency
+ * link rather than failing on intentionally app-provided symbols. */
+struct ifaddrs;
+void peer_log(char* level, const char* file, int line, const char* fmt, ...) {
+  (void)level; (void)file; (void)line; (void)fmt;
+}
+int getifaddrs(struct ifaddrs** out) { (void)out; return -1; }
+void freeifaddrs(struct ifaddrs* list) { (void)list; }
+unsigned int if_nametoindex(const char* name) { (void)name; return 1; }
+char* if_indextoname(unsigned int index, char* name) {
+  (void)index; return name;
+}
+int mbedtls_hardware_poll(void* data, unsigned char* out, size_t len,
+                          size_t* olen) {
+  (void)data;
+  randomGet(out, len);
+  if (olen) *olen = len;
+  return 0;
+}
+
 int main(void) {
   peer_init();
   PeerConfiguration config = {0};
@@ -118,26 +143,31 @@ fi
 
 # 2) Apply patches (idempotent: skipped when already applied).
 apply_patch() {
-  local dir="$1" patch="$2"
-  if git -C "$dir" apply --reverse --check "$patch" >/dev/null 2>&1; then
+  local dir="$1" patch="$2"; shift 2
+  if git -C "$dir" apply "$@" --reverse --check "$patch" >/dev/null 2>&1; then
     echo "patch already applied: $(basename "$patch")"
   else
     echo "applying patch: $(basename "$patch")"
-    git -C "$dir" apply "$patch"
+    git -C "$dir" apply "$@" "$patch"
   fi
 }
-apply_patch "$LIBPEER_DIR" "$DEPS_DIR/patches/libpeer-switch.patch"
+# The patch was generated while these submodules had their own working-tree
+# changes, so its tail contains synthetic "<sha>-dirty" gitlink entries. Git
+# cannot apply those as object IDs; the real submodule changes are applied by
+# their dedicated patches immediately below.
+apply_patch "$LIBPEER_DIR" "$DEPS_DIR/patches/libpeer-switch.patch" \
+  --exclude=third_party/mbedtls --exclude=third_party/usrsctp
 apply_patch "$LIBPEER_DIR/third_party/mbedtls" "$DEPS_DIR/patches/mbedtls-switch.patch"
 apply_patch "$LIBPEER_DIR/third_party/usrsctp" "$DEPS_DIR/patches/usrsctp-switch.patch"
 
 # 3) Build everything inside the devkitPro container.
 rm -rf "$DEPS_DIR/switch"
-docker run --rm -v "$DEPS_DIR":/work/deps "$DOCKER_IMAGE" \
+MSYS_NO_PATHCONV=1 docker run --rm -v "$DEPS_DIR":/work/deps "$DOCKER_IMAGE" \
   bash /work/deps/build-switch.sh --inside
 
 # 4) Fix ownership of files the container may have created as root
 #    (no-op on Docker Desktop for Mac, needed on Linux hosts).
-docker run --rm -v "$DEPS_DIR":/work/deps "$DOCKER_IMAGE" \
+MSYS_NO_PATHCONV=1 docker run --rm -v "$DEPS_DIR":/work/deps "$DOCKER_IMAGE" \
   chown -R "$(id -u):$(id -g)" /work/deps/switch /work/deps/src >/dev/null 2>&1 || true
 
 # 5) Verify artifacts.

--- a/deps/patches/libpeer-switch.patch
+++ b/deps/patches/libpeer-switch.patch
@@ -271,7 +271,6 @@ index c763e80..47f677c 100644
 +          ntp_frac = ntohl(ntp_frac);
 +          pc->rtcp_last_sr_lsr = (ntp_sec << 16) | (ntp_frac >> 16);
 +          pc->rtcp_last_sr_time = ports_get_epoch_time();
-+          LOGI("RTCP SR received (lsr=%08x)", pc->rtcp_last_sr_lsr);
 +        }
 +        break;
 +      }

--- a/shaders/video_fsh.glsl
+++ b/shaders/video_fsh.glsl
@@ -14,16 +14,127 @@ layout (std140, binding = 0) uniform Transformation
     mat3 yuvmat;
     vec3 offset;
     vec4 uv_data;
+    vec4 sharp_data;
+    vec4 contrast_data;
 } u;
 
 void main()
 {
     vec2 uv = (vTextureCoord - u.uv_data.xy) * u.uv_data.zw;
 
-    vec3 yuv = vec3(texture(plane0, uv).r,
+    float y = texture(plane0, uv).r;
+    if (u.sharp_data.x > 0.0) {
+        vec2 px = 1.0 / vec2(textureSize(plane0, 0));
+        float yl = texture(plane0, uv - vec2(px.x, 0.0)).r;
+        float yr = texture(plane0, uv + vec2(px.x, 0.0)).r;
+        float yu = texture(plane0, uv - vec2(0.0, px.y)).r;
+        float yd = texture(plane0, uv + vec2(0.0, px.y)).r;
+        float average = 0.25 * (yl + yr + yu + yd);
+        float lo = min(y, min(min(yl, yr), min(yu, yd)));
+        float hi = max(y, max(max(yl, yr), max(yu, yd)));
+        y = clamp(y + (y - average) * u.sharp_data.x,
+                  max(0.0, lo - u.sharp_data.y),
+                  min(1.0, hi + u.sharp_data.y));
+    }
+
+    vec3 yuv = vec3(y,
                     texture(plane1, uv).r,
                     texture(plane1, uv).g) - u.offset;
     vec3 rgb = u.yuvmat * yuv;
 
-    outColor = vec4(clamp(rgb, 0.0, 1.0), 1.0);
+    rgb = clamp(rgb, 0.0, 1.0);
+    // Endpoint-protected S-curve: deepens shadows and lifts highlights while
+    // preserving true black, true white, and the mid-point.
+    rgb += u.contrast_data.x * (rgb - vec3(0.5)) *
+           (vec3(1.0) - abs(rgb * 2.0 - vec3(1.0)));
+    rgb = clamp(rgb, 0.0, 1.0);
+
+    // Strobe-test overlay. A tiny 5x7 bitmap font is generated in the shader
+    // so deko3d does not need SDL/font ownership while streaming.
+    if (u.sharp_data.z > 0.0) {
+        vec2 p = vec2(gl_FragCoord.x - 10.0, gl_FragCoord.y - 10.0);
+        if (p.x >= -6.0 && p.x < 250.0 && p.y >= -6.0 && p.y < 30.0)
+            rgb = mix(rgb, vec3(0.0), 0.72);
+
+        ivec2 cell = ivec2(floor(p / 3.0));
+        int slot = cell.x / 6;
+        ivec2 gp = ivec2(cell.x - slot * 6, cell.y);
+        int mode = int(u.sharp_data.z) - 1;
+        int ch = -1;
+        // Character ids: A,D,E,F,G,H,I,L,M,O,P,R,S,W,X,U,T.
+        if (slot == 0) ch = 12;      // S
+        else if (slot == 1) ch = 5;  // H
+        else if (slot == 2) ch = 0;  // A
+        else if (slot == 3) ch = 11; // R
+        else if (slot == 4) ch = 10; // P
+        else if (slot >= 6) {
+            int n = slot - 6;
+            if (mode == 0) { int s[3] = int[3](9, 3, 3); if (n < 3) ch=s[n]; }
+            if (mode == 1) { int s[3] = int[3](7, 9, 13); if (n < 3) ch=s[n]; }
+            if (mode == 2) { int s[6] = int[6](8, 2, 1, 6, 15, 8); if(n<6)ch=s[n]; }
+            if (mode == 3) { int s[4] = int[4](5, 6, 4, 5); if (n < 4) ch=s[n]; }
+            if (mode == 4) { int s[7] = int[7](2, 14, 16, 11, 2, 8, 2); if(n<7)ch=s[n]; }
+        }
+        if (ch >= 0 && gp.x >= 0 && gp.x < 5 && gp.y >= 0 && gp.y < 7) {
+            const uint rows[140] = uint[140](
+                14,17,17,31,17,17,17, 30,17,17,17,17,17,30,
+                31,16,16,30,16,16,31, 31,16,16,30,16,16,16,
+                14,17,16,23,17,17,15, 17,17,17,31,17,17,17,
+                31,4,4,4,4,4,31, 16,16,16,16,16,16,31,
+                17,27,21,17,17,17,17, 14,17,17,17,17,17,14,
+                30,17,17,30,16,16,16, 30,17,17,30,20,18,17,
+                15,16,16,14,1,1,30, 17,17,17,17,21,21,10,
+                31,1,2,4,8,16,31, 17,17,17,17,17,17,14,
+                31,4,4,4,4,4,4, 14,17,16,16,16,17,14,
+                17,25,21,19,17,17,17, 31,4,4,4,4,4,4);
+            uint row = rows[ch * 7 + gp.y];
+            if (((row >> uint(4 - gp.x)) & 1u) != 0u)
+                rgb = vec3(1.0, 0.9, 0.2);
+        }
+    }
+
+    if (u.contrast_data.y > 0.0) {
+        vec2 p = vec2(gl_FragCoord.x - 10.0, gl_FragCoord.y - 50.0);
+        if (p.x >= -6.0 && p.x < 310.0 && p.y >= -6.0 && p.y < 30.0)
+            rgb = mix(rgb, vec3(0.0), 0.72);
+        ivec2 cell = ivec2(floor(p / 3.0));
+        int slot = cell.x / 6;
+        ivec2 gp = ivec2(cell.x - slot * 6, cell.y);
+        int mode = int(u.contrast_data.y) - 1;
+        int ch = -1;
+        // CONTRAST prefix. ids 17=C, 18=N, 19=T.
+        if (slot == 0) ch = 17;
+        else if (slot == 1) ch = 9;
+        else if (slot == 2) ch = 18;
+        else if (slot == 3) ch = 19;
+        else if (slot == 4) ch = 11;
+        else if (slot == 5) ch = 0;
+        else if (slot == 6) ch = 12;
+        else if (slot == 7) ch = 19;
+        else if (slot >= 9) {
+            int n = slot - 9;
+            if (mode == 0) { int s[3] = int[3](9, 3, 3); if (n < 3) ch=s[n]; }
+            if (mode == 1) { int s[3] = int[3](7, 9, 13); if (n < 3) ch=s[n]; }
+            if (mode == 2) { int s[6] = int[6](8, 2, 1, 6, 15, 8); if(n<6)ch=s[n]; }
+            if (mode == 3) { int s[4] = int[4](5, 6, 4, 5); if (n < 4) ch=s[n]; }
+        }
+        if (ch >= 0 && gp.x >= 0 && gp.x < 5 && gp.y >= 0 && gp.y < 7) {
+            const uint rows[140] = uint[140](
+                14,17,17,31,17,17,17, 30,17,17,17,17,17,30,
+                31,16,16,30,16,16,31, 31,16,16,30,16,16,16,
+                14,17,16,23,17,17,15, 17,17,17,31,17,17,17,
+                31,4,4,4,4,4,31, 16,16,16,16,16,16,31,
+                17,27,21,17,17,17,17, 14,17,17,17,17,17,14,
+                30,17,17,30,16,16,16, 30,17,17,30,20,18,17,
+                15,16,16,14,1,1,30, 17,17,17,17,21,21,10,
+                31,1,2,4,8,16,31, 17,17,17,17,17,17,14,
+                31,4,4,4,4,4,4, 14,17,16,16,16,17,14,
+                17,25,21,19,17,17,17, 31,4,4,4,4,4,4);
+            uint row = rows[ch * 7 + gp.y];
+            if (((row >> uint(4 - gp.x)) & 1u) != 0u)
+                rgb = vec3(0.3, 0.9, 1.0);
+        }
+    }
+
+    outColor = vec4(rgb, 1.0);
 }

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -134,6 +134,9 @@ struct SwitchRumble {
 
 struct Settings {
     int quality = 2;    // 0=720p, 1=1080p, 2=1080p HQ
+    int pacing = 0;     // 0=low latency, 1=smooth
+    int sharpness = 2;  // 0..4 fixed strength, 5=strobe test
+    int contrast = 0;   // 0..3 fixed strength, 4=strobe test
     int mapping = 0;    // 0=positional, 1=match labels
     int vibration = 2;  // rumble intensity: 0=Off, 1=Low, 2=Medium, 3=High
     int region = 0;     // region-bypass IP: 0=Off, else index into kRegion*
@@ -197,6 +200,9 @@ Settings load_settings() {
     json data = json::parse(in, nullptr, false);
     if (data.is_discarded()) return settings;
     settings.quality = std::clamp(data.value("quality", 2), 0, 2);
+    settings.pacing = std::clamp(data.value("pacing", 0), 0, 1);
+    settings.sharpness = std::clamp(data.value("sharpness", 2), 0, 5);
+    settings.contrast = std::clamp(data.value("contrast", 0), 0, 4);
     settings.mapping = std::clamp(data.value("mapping", 0), 0, 1);
     // "vibration" was an on/off bool before intensity levels existed; migrate.
     if (data.contains("vibration") && data["vibration"].is_boolean())
@@ -213,6 +219,9 @@ Settings load_settings() {
 void save_settings(const Settings& settings) {
     std::ofstream out(data_path("settings.json"), std::ios::trunc);
     out << json{{"quality", settings.quality},
+                {"pacing", settings.pacing},
+                {"sharpness", settings.sharpness},
+                {"contrast", settings.contrast},
                 {"mapping", settings.mapping},
                 {"vibration", settings.vibration},
                 {"region", settings.region},
@@ -620,6 +629,11 @@ void draw_library(App& app) {
 }
 
 const char* kQualityLabels[3] = {"720p", "1080p", "1080p high bitrate"};
+const char* kPacingLabels[2] = {"Low latency", "Smooth"};
+const char* kSharpnessLabels[6] = {
+    "Off", "Low", "Medium", "High", "Extreme", "Strobe test"};
+const char* kContrastLabels[5] = {
+    "Off", "Low", "Medium", "High", "Strobe test"};
 const char* kMappingLabels[2] = {"Positional (Switch A = Xbox B)",
                                  "Match labels (Switch A = Xbox A)"};
 
@@ -630,40 +644,72 @@ void draw_settings(App& app) {
         const char* title;
         std::string value;
     };
-    Row rows[5] = {
+    Row rows[8] = {
         {"Stream quality", kQualityLabels[app.settings.quality]},
+        {"Video pacing", kPacingLabels[app.settings.pacing]},
+        {"Luma sharpening", kSharpnessLabels[app.settings.sharpness]},
+        {"Contrast", kContrastLabels[app.settings.contrast]},
         {"Button layout", kMappingLabels[app.settings.mapping]},
         {"Vibration", kVibrationLabels[app.settings.vibration]},
         {"Region bypass", kRegionLabels[app.settings.region]},
         {"Game language", kLanguageLabels[app.settings.language]},
     };
-    for (int i = 0; i < 5; ++i) {
-        SDL_Rect row = {120, 170 + i * 118, gfx::kWidth - 240, 94};
+    for (int i = 0; i < 8; ++i) {
+        SDL_Rect row = {120, 70 + i * 82, gfx::kWidth - 240, 64};
         app.gfx.fill(row, gfx::kCard);
         if (i == app.settings_cursor) app.gfx.frame(row, gfx::kCardFocus, 4);
-        app.gfx.text(rows[i].title, row.x + 40, row.y + 27,
+        app.gfx.text(rows[i].title, row.x + 40, row.y + 12,
                      gfx::FontSize::Body, gfx::kText);
         app.gfx.text(rows[i].value,
                      row.x + row.w - 40 -
                          app.gfx.text_width(rows[i].value,
                                             gfx::FontSize::Body),
-                     row.y + 27, gfx::FontSize::Body, gfx::kAccent);
+                     row.y + 12, gfx::FontSize::Body, gfx::kAccent);
     }
-    const char* note;
-    if (app.settings_cursor == 4)
-        note =
-            "Sets the streamed console's language. Applies to games that have "
-            "no in-game language menu; takes effect on the next launch.";
-    else if (app.settings.region != 0)
-        note =
+    const char* note_line_1;
+    const char* note_line_2 = nullptr;
+    if (app.settings_cursor == 7) {
+        note_line_1 =
+            "Sets the streamed console's language for games without a "
+            "language menu.";
+        note_line_2 = "The change takes effect the next time a game launches.";
+    } else if (app.settings_cursor == 1) {
+        note_line_1 =
+            "Low latency shows the newest frame immediately. Smooth keeps one "
+            "frame in reserve";
+        note_line_2 =
+            "for steadier motion, with about one source frame of added delay.";
+    } else if (app.settings_cursor == 2) {
+        note_line_1 =
+            "Medium is recommended. Sharpening restores brightness detail; "
+            "Off keeps the source image.";
+        note_line_2 =
+            "Strobe test cycles Off, Low, Medium, High and Extreme every 3 "
+            "seconds and labels each mode.";
+    } else if (app.settings_cursor == 3) {
+        note_line_1 =
+            "Medium is recommended. Contrast adds depth while protecting "
+            "black and white endpoints.";
+        note_line_2 =
+            "Strobe test cycles Off, Low, Medium and High every 3 seconds and "
+            "labels each mode.";
+    } else if (app.settings.region != 0) {
+        note_line_1 =
             "Region bypass spoofs your location to Xbox to reach xCloud from "
-            "an unsupported country. Use your own account at your own risk.";
-    else
-        note =
-            "Higher quality needs a stronger connection - 5 GHz Wi-Fi or "
-            "docked LAN recommended for 1080p high bitrate";
-    app.gfx.text_centered(note, gfx::kWidth / 2, 800, gfx::FontSize::Small,
-                          gfx::kTextDim);
+            "an unsupported country.";
+        note_line_2 = "Use your own account at your own risk.";
+    } else {
+        note_line_1 =
+            "Higher quality needs a stronger connection. Use 5 GHz Wi-Fi or "
+            "docked LAN";
+        note_line_2 = "for 1080p high bitrate.";
+    }
+    const int note_y = note_line_2 ? 775 : 800;
+    app.gfx.text_centered(note_line_1, gfx::kWidth / 2, note_y,
+                          gfx::FontSize::Small, gfx::kTextDim);
+    if (note_line_2)
+        app.gfx.text_centered(note_line_2, gfx::kWidth / 2, note_y + 34,
+                              gfx::FontSize::Small, gfx::kTextDim);
     draw_footer(app, "Left / Right  Change   B  Back");
 }
 
@@ -1035,7 +1081,9 @@ int main(int argc, char** argv) {
                     app.engine->start(
                         app.launch_game.title_id,
                         static_cast<QualityTier>(app.settings.quality),
-                        kLanguageCodes[app.settings.language]);
+                        kLanguageCodes[app.settings.language],
+                        static_cast<stream::VideoPacing>(app.settings.pacing),
+                        app.settings.sharpness, app.settings.contrast);
                     app.stream_hint_until = SDL_GetTicks() + 8000;
                     app.scene = Scene::Stream;
 #endif
@@ -1048,21 +1096,30 @@ int main(int argc, char** argv) {
                 if (input.up)
                     app.settings_cursor = std::max(0, app.settings_cursor - 1);
                 if (input.down)
-                    app.settings_cursor = std::min(4, app.settings_cursor + 1);
+                    app.settings_cursor = std::min(7, app.settings_cursor + 1);
                 int direction = (input.right ? 1 : 0) - (input.left ? 1 : 0);
                 if (direction != 0) {
                     if (app.settings_cursor == 0)
                         app.settings.quality =
                             (app.settings.quality + direction + 3) % 3;
                     else if (app.settings_cursor == 1)
+                        app.settings.pacing =
+                            (app.settings.pacing + direction + 2) % 2;
+                    else if (app.settings_cursor == 2)
+                        app.settings.sharpness =
+                            (app.settings.sharpness + direction + 6) % 6;
+                    else if (app.settings_cursor == 3)
+                        app.settings.contrast =
+                            (app.settings.contrast + direction + 5) % 5;
+                    else if (app.settings_cursor == 4)
                         app.settings.mapping =
                             (app.settings.mapping + direction + 2) % 2;
-                    else if (app.settings_cursor == 2)
+                    else if (app.settings_cursor == 5)
                         app.settings.vibration =
                             (app.settings.vibration + direction +
                              kVibrationLevels) %
                             kVibrationLevels;
-                    else if (app.settings_cursor == 3) {
+                    else if (app.settings_cursor == 6) {
                         app.settings.region =
                             (app.settings.region + direction + 6) % 6;
                         apply_region(app.settings);  // takes effect next request
@@ -1101,7 +1158,10 @@ int main(int argc, char** argv) {
                         app.engine->start(
                             app.launch_game.title_id,
                             static_cast<QualityTier>(app.settings.quality),
-                            kLanguageCodes[app.settings.language]);
+                            kLanguageCodes[app.settings.language],
+                            static_cast<stream::VideoPacing>(
+                                app.settings.pacing),
+                            app.settings.sharpness, app.settings.contrast);
                         app.stream_hint_until = SDL_GetTicks() + 8000;
                     }
                 } else if (input.b) {  // cancel while connecting

--- a/src/switch/stream/audio_jitter.cpp
+++ b/src/switch/stream/audio_jitter.cpp
@@ -11,6 +11,13 @@ namespace {
 constexpr size_t kMaxLate = 32;
 }  // namespace
 
+void AudioJitterBuffer::reset() {
+    pending_.clear();
+    next_seq_ = 0;
+    have_next_ = false;
+    lost_ = 0;
+}
+
 void AudioJitterBuffer::push(uint16_t seq, const uint8_t* data, size_t size) {
     if (!have_next_) {
         next_seq_ = seq;

--- a/src/switch/stream/audio_jitter.hpp
+++ b/src/switch/stream/audio_jitter.hpp
@@ -15,6 +15,9 @@ namespace gnx::stream {
 // Mirrors green-vita's SampleBuilder (32 late packets max).
 class AudioJitterBuffer {
 public:
+    // Start a new RTP sequence space. Required between xCloud sessions because
+    // the server chooses a fresh, unrelated initial sequence number.
+    void reset();
     // Add one arriving Opus payload tagged with its RTP sequence number.
     void push(uint16_t seq, const uint8_t* data, size_t size);
     // Move the next in-sequence packet into `out` if one is ready; returns

--- a/src/switch/stream/audio_player.cpp
+++ b/src/switch/stream/audio_player.cpp
@@ -33,6 +33,25 @@ constexpr u64 kOutWaitNs = 100000000ULL;  // 100 ms; re-check quit_ on timeout
 }  // namespace
 
 bool AudioPlayer::init() {
+    // Engine instances are reused when returning to the library and launching
+    // another stream. A new session has a new RTP sequence space, so no audio
+    // reorder or telemetry state may leak across starts.
+    reorder_.reset();
+    {
+        std::lock_guard<std::mutex> lock(inbox_mutex_);
+        inbox_.clear();
+    }
+    received_.store(0, std::memory_order_relaxed);
+    played_.store(0, std::memory_order_relaxed);
+    failed_.store(0, std::memory_order_relaxed);
+    lost_.store(0, std::memory_order_relaxed);
+    underruns_.store(0, std::memory_order_relaxed);
+    dropped_samples_.store(0, std::memory_order_relaxed);
+    frames_.store(0, std::memory_order_relaxed);
+    out_samples_.store(0, std::memory_order_relaxed);
+    ema_ms_.store(0, std::memory_order_relaxed);
+    adj_ppm_.store(0, std::memory_order_relaxed);
+
     int error = 0;
     decoder_ = opus_decoder_create(kSampleRate, kChannels, &error);
     if (error != OPUS_OK) return false;

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -1,9 +1,11 @@
 #include "dk_video_renderer.hpp"
 
+#include <SDL2/SDL.h>
 #include <switch.h>
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdio>
 #include <cstring>
 
@@ -34,6 +36,19 @@ struct Vertex {
     float uv[2];
 };
 
+uint64_t elapsed_us(std::chrono::steady_clock::time_point start) {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::steady_clock::now() - start).count());
+}
+
+void update_max(std::atomic<uint64_t>& target, uint64_t value) {
+    uint64_t current = target.load(std::memory_order_relaxed);
+    while (current < value &&
+           !target.compare_exchange_weak(current, value,
+                                         std::memory_order_relaxed)) {}
+}
+
 // Fullscreen quad. deko3d clip space, UV top-left origin.
 constexpr Vertex kQuad[] = {
     {{-1.0f, +1.0f, 0.0f}, {0.0f, 0.0f}},
@@ -42,15 +57,17 @@ constexpr Vertex kQuad[] = {
     {{+1.0f, +1.0f, 0.0f}, {1.0f, 0.0f}},
 };
 
-// std140 layout for: mat3 yuvmat; vec3 offset; vec4 uv_data;
+// std140 video transform and image-enhancement controls.
 struct Transformation {
     alignas(16) float yuvmat_col0[4];
     alignas(16) float yuvmat_col1[4];
     alignas(16) float yuvmat_col2[4];
     alignas(16) float offset[4];
     alignas(16) float uv_data[4];
+    alignas(16) float sharp_data[4];
+    alignas(16) float contrast_data[4];
 };
-static_assert(sizeof(Transformation) == 80, "std140 Transformation");
+static_assert(sizeof(Transformation) == 112, "std140 Transformation");
 
 // Column-major YUV->RGB matrices (matching Moonlight-Switch / BT.xxx).
 const float kBt601Lim[9] = {1.1644f, 1.1644f, 1.1644f, 0.0f,    -0.3917f,
@@ -340,9 +357,23 @@ void DkVideoRenderer::update_transform(AVFrame* frame) {
     t.uv_data[1] = 0.0f;
     t.uv_data[2] = luma_w_ ? (float)frame_w_ / (float)luma_w_ : 1.0f;
     t.uv_data[3] = luma_h_ ? (float)frame_h_ / (float)luma_h_ : 1.0f;
+    static constexpr float kSharpness[5] = {0.0f, 0.60f, 1.20f, 2.0f, 3.0f};
+    static constexpr float kOvershoot[5] = {0.0f, 0.02f, 0.035f, 0.05f, 0.075f};
+    t.sharp_data[0] = kSharpness[effective_sharpness_];
+    t.sharp_data[1] = kOvershoot[effective_sharpness_];
+    t.sharp_data[2] = sharpness_ == 5
+                          ? static_cast<float>(effective_sharpness_ + 1) : 0.0f;
+    t.sharp_data[3] = static_cast<float>(fb_height_);
+    static constexpr float kContrast[4] = {0.0f, 0.18f, 0.34f, 0.55f};
+    t.contrast_data[0] = kContrast[effective_contrast_];
+    t.contrast_data[1] = contrast_ == 4
+                             ? static_cast<float>(effective_contrast_ + 1)
+                             : 0.0f;
     std::memcpy(static_cast<uint8_t*>(data_cpu_) + kUniformOff, &t, sizeof(t));
-    logf("deko3d: color space=%d full=%d crop=%.4fx%.4f", space, (int)full,
-         t.uv_data[2], t.uv_data[3]);
+    logf("deko3d: color space=%d full=%d crop=%.4fx%.4f sharp=%d%s contrast=%d%s", space,
+         (int)full, t.uv_data[2], t.uv_data[3], effective_sharpness_,
+         sharpness_ == 5 ? " (strobe)" : "", effective_contrast_,
+         contrast_ == 4 ? " (strobe)" : "");
 }
 
 DkVideoRenderer::FrameMapping* DkVideoRenderer::map_frame(AVFrame* frame,
@@ -396,6 +427,20 @@ DkVideoRenderer::FrameMapping* DkVideoRenderer::map_frame(AVFrame* frame,
 bool DkVideoRenderer::render(AVFrame* frame) {
     if (!initialized_) return false;
     maybe_rebuild_swapchain();  // follow dock/undock (720p <-> 1080p)
+    int active_sharpness =
+        sharpness_ == 5 ? static_cast<int>((SDL_GetTicks64() / 3000) % 5)
+                        : sharpness_;
+    if (active_sharpness != effective_sharpness_) {
+        effective_sharpness_ = active_sharpness;
+        transform_dirty_ = true;
+    }
+    int active_contrast =
+        contrast_ == 4 ? static_cast<int>((SDL_GetTicks64() / 3000) % 4)
+                       : contrast_;
+    if (active_contrast != effective_contrast_) {
+        effective_contrast_ = active_contrast;
+        transform_dirty_ = true;
+    }
     if (!swapchain_) return false;
     if (frame->format != AV_PIX_FMT_NVTEGRA) {
         if (!warned_not_hw_) {
@@ -444,7 +489,9 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     FrameMapping* fm = map_frame(frame, base, handle, size);
     if (!fm) return false;
 
+    auto acquire_started = std::chrono::steady_clock::now();
     int slot = queue_.acquireImage(swapchain_);
+    uint64_t acquire_us = elapsed_us(acquire_started);
 
     cmdbuf_.clear();
     cmdbuf_.addMemory(cmd_memblock_, 0, kCmdSize);
@@ -500,9 +547,39 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
 
     queue_.submitCommands(cmdbuf_.finishList());
+    auto present_started = std::chrono::steady_clock::now();
     queue_.presentImage(swapchain_, slot);
+    uint64_t present_us = elapsed_us(present_started);
+    auto idle_started = std::chrono::steady_clock::now();
     queue_.waitIdle();
+    uint64_t idle_us = elapsed_us(idle_started);
+
+    timing_renders_.fetch_add(1, std::memory_order_relaxed);
+    timing_acquire_total_us_.fetch_add(acquire_us, std::memory_order_relaxed);
+    timing_present_total_us_.fetch_add(present_us, std::memory_order_relaxed);
+    timing_idle_total_us_.fetch_add(idle_us, std::memory_order_relaxed);
+    update_max(timing_acquire_max_us_, acquire_us);
+    update_max(timing_present_max_us_, present_us);
+    update_max(timing_idle_max_us_, idle_us);
     return true;
+}
+
+DkVideoRenderer::TimingStats DkVideoRenderer::take_timing_stats() {
+    TimingStats stats;
+    stats.renders = timing_renders_.exchange(0, std::memory_order_relaxed);
+    stats.acquire_total_us =
+        timing_acquire_total_us_.exchange(0, std::memory_order_relaxed);
+    stats.acquire_max_us =
+        timing_acquire_max_us_.exchange(0, std::memory_order_relaxed);
+    stats.present_total_us =
+        timing_present_total_us_.exchange(0, std::memory_order_relaxed);
+    stats.present_max_us =
+        timing_present_max_us_.exchange(0, std::memory_order_relaxed);
+    stats.idle_total_us =
+        timing_idle_total_us_.exchange(0, std::memory_order_relaxed);
+    stats.idle_max_us =
+        timing_idle_max_us_.exchange(0, std::memory_order_relaxed);
+    return stats;
 }
 
 }  // namespace gnx::stream

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -12,6 +12,7 @@
 
 #include <cstdarg>
 #include <cstdint>
+#include <atomic>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -36,6 +37,14 @@ public:
     DkVideoRenderer& operator=(const DkVideoRenderer&) = delete;
 
     void set_logger(LogFn fn) { log_ = std::move(fn); }
+    void set_sharpness(int level) {
+        sharpness_ = level < 0 ? 0 : (level > 5 ? 5 : level);
+        transform_dirty_ = true;
+    }
+    void set_contrast(int level) {
+        contrast_ = level < 0 ? 0 : (level > 4 ? 4 : level);
+        transform_dirty_ = true;
+    }
 
     // Bring up the deko3d device/swapchain. Call after SDL has released the
     // window. Returns false (and logs) on failure.
@@ -47,6 +56,18 @@ public:
     bool render(AVFrame* frame);
 
     bool initialized() const { return initialized_; }
+
+    struct TimingStats {
+        uint64_t renders = 0;
+        uint64_t acquire_total_us = 0;
+        uint64_t acquire_max_us = 0;
+        uint64_t present_total_us = 0;
+        uint64_t present_max_us = 0;
+        uint64_t idle_total_us = 0;
+        uint64_t idle_max_us = 0;
+    };
+    // Return and reset render timing accumulated since the previous call.
+    TimingStats take_timing_stats();
 
 private:
     // Triple-buffered: with the ~60 Hz software present pacer (Engine::pump_video)
@@ -130,6 +151,18 @@ private:
     bool color_full_ = false;
     bool warned_not_hw_ = false;
     bool logged_surface_ = false;
+    int sharpness_ = 2;            // 0..4 fixed; 5 = 3-second strobe test
+    int effective_sharpness_ = -1; // actual 0..4 level currently rendered
+    int contrast_ = 0;             // 0..3 fixed; 4 = 3-second strobe test
+    int effective_contrast_ = -1;
+
+    std::atomic<uint64_t> timing_renders_{0};
+    std::atomic<uint64_t> timing_acquire_total_us_{0};
+    std::atomic<uint64_t> timing_acquire_max_us_{0};
+    std::atomic<uint64_t> timing_present_total_us_{0};
+    std::atomic<uint64_t> timing_present_max_us_{0};
+    std::atomic<uint64_t> timing_idle_total_us_{0};
+    std::atomic<uint64_t> timing_idle_max_us_{0};
 };
 
 }  // namespace gnx::stream

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -22,6 +22,36 @@ namespace {
 // libpeer's LOG_REDIRECT sink funnels through this single active engine.
 gnx::stream::Engine* g_log_engine = nullptr;
 
+void atomic_max(std::atomic<uint64_t>& target, uint64_t value) {
+    uint64_t current = target.load(std::memory_order_relaxed);
+    while (current < value &&
+           !target.compare_exchange_weak(current, value,
+                                         std::memory_order_relaxed)) {}
+}
+
+uint64_t counter_delta_us(uint64_t start, uint64_t end) {
+    uint64_t frequency = SDL_GetPerformanceFrequency();
+    return frequency && end >= start ? (end - start) * 1000000ull / frequency : 0;
+}
+
+void record_cadence(
+    uint64_t delta_us, std::atomic<uint64_t>& lt25,
+    std::atomic<uint64_t>& from25to40, std::atomic<uint64_t>& from40to55,
+    std::atomic<uint64_t>& from55to75, std::atomic<uint64_t>& gt75,
+    std::atomic<uint64_t>& maximum) {
+    if (delta_us < 25000)
+        lt25.fetch_add(1, std::memory_order_relaxed);
+    else if (delta_us < 40000)
+        from25to40.fetch_add(1, std::memory_order_relaxed);
+    else if (delta_us < 55000)
+        from40to55.fetch_add(1, std::memory_order_relaxed);
+    else if (delta_us < 75000)
+        from55to75.fetch_add(1, std::memory_order_relaxed);
+    else
+        gt75.fetch_add(1, std::memory_order_relaxed);
+    atomic_max(maximum, delta_us);
+}
+
 // Route ffmpeg's own diagnostics (H.264 reference errors, concealment, ...)
 // into stream-log; without this the decoder's complaints are invisible.
 void av_log_capture(void* avcl, int level, const char* fmt, va_list vl) {
@@ -106,24 +136,38 @@ void Engine::log(const std::string& line) {
     std::fprintf(log_file_, "[%8llu] %s\n",
                  static_cast<unsigned long long>(SDL_GetTicks64()),
                  line.c_str());
-    std::fflush(log_file_);
 }
 
 void Engine::start(const std::string& title_id, QualityTier tier,
-                   const std::string& locale) {
+                   const std::string& locale, VideoPacing pacing,
+                   int sharpness, int contrast) {
     stop();
     title_id_ = title_id;
     tier_ = tier;
     locale_ = locale;
+    pacing_ = pacing;
+    sharpness_ = std::clamp(sharpness, 0, 5);
+    contrast_ = std::clamp(contrast, 0, 4);
     {
         std::lock_guard<std::mutex> lock(log_mutex_);
         if (log_file_) std::fclose(log_file_);
 #ifdef __SWITCH__
         // Keep the previous session's log: rotate instead of overwrite.
-        std::remove("sdmc:/switch/green-nx/stream-log-prev.txt");
-        std::rename("sdmc:/switch/green-nx/stream-log.txt",
-                    "sdmc:/switch/green-nx/stream-log-prev.txt");
-        log_file_ = std::fopen("sdmc:/switch/green-nx/stream-log.txt", "w");
+        const char* mode = pacing_ == VideoPacing::Smooth
+                               ? "smooth" : "low-latency";
+        std::string current = std::string("sdmc:/switch/green-nx/stream-log-") +
+                              mode + ".txt";
+        std::string previous =
+            std::string("sdmc:/switch/green-nx/stream-log-") + mode +
+            "-prev.txt";
+        std::remove(previous.c_str());
+        std::rename(current.c_str(), previous.c_str());
+        log_file_ = std::fopen(current.c_str(), "w");
+        // Logging is diagnostic and must not stall the sole RTP socket pump.
+        // A synchronous fflush for the once-per-second audio line was enough
+        // to produce a small regular video hitch on SD cards. Keep the session
+        // in memory and let fclose() flush it on clean stream shutdown.
+        if (log_file_) std::setvbuf(log_file_, nullptr, _IOFBF, 256 * 1024);
 #else
         log_file_ = stderr;
 #endif
@@ -135,8 +179,16 @@ void Engine::start(const std::string& title_id, QualityTier tier,
     const char* tier_name = tier == QualityTier::P720      ? "720p/android"
                             : tier == QualityTier::P1080   ? "1080p/windows"
                                                            : "1080pHQ/tizen";
+    const char* pacing_name =
+        pacing_ == VideoPacing::Smooth ? "smooth" : "low-latency";
+    static const char* kSharpnessNames[] = {
+        "off", "low", "medium", "high", "extreme", "strobe"};
+    static const char* kContrastNames[] = {
+        "off", "low", "medium", "high", "strobe"};
     log("green-nx v" GNX_VERSION " | stream start: " + title_id + " | tier " +
-        tier_name);
+        tier_name + " | pacing " + pacing_name + " | sharpness " +
+        kSharpnessNames[sharpness_] + " | contrast " +
+        kContrastNames[contrast_]);
     quit_ = false;
     got_frame_ = false;
     channels_open_ = false;
@@ -144,7 +196,19 @@ void Engine::start(const std::string& title_id, QualityTier tier,
     pli_sent_ = 0;
     install_av_log_capture();
     jitter_.reset();
-    next_present_ms_ = 0;  // first frame presents immediately, then paced
+    next_present_counter_ = 0;  // first frame presents immediately, then paced
+#ifdef __SWITCH__
+    diag_last_marker_counter_ = 0;
+    diag_last_au_counter_ = 0;
+    shared_frame_seq_ = 0;
+    last_present_seq_ = 0;
+    present_hold_refreshes_ = 0;
+    smooth_have_present_ = false;
+    smooth_refresh_phase_ = 0;
+    source_refresh_period_ = 1;
+    source_fast_streak_ = source_slow_streak_ = 0;
+    smooth_frames_.clear();
+#endif
     state_ = EngineState::StartingSession;
     video_.init(renderer_);
     audio_.init();
@@ -189,6 +253,7 @@ void Engine::stop() {
     {
         std::lock_guard<std::mutex> lock(video_mutex_);
         video_queue_.clear();
+        video_queue_times_.clear();
     }
 #ifdef __SWITCH__
     {
@@ -197,6 +262,9 @@ void Engine::stop() {
         std::lock_guard<std::mutex> lock(frame_mutex_);
         if (shared_frame_) av_frame_free(&shared_frame_);
         if (present_frame_) av_frame_free(&present_frame_);
+        for (auto& queued : smooth_frames_)
+            if (queued.frame) av_frame_free(&queued.frame);
+        smooth_frames_.clear();
         shared_frame_valid_ = false;
     }
 #endif
@@ -234,15 +302,38 @@ void Engine::on_video(uint8_t* data, size_t size, void* user) {
     // held). `data` is a raw RTP packet; the jitter buffer reorders/assembles
     // complete access units and only emits clean, keyframe-anchored frames.
     auto* self = static_cast<Engine*>(user);
+    // RTP marker denotes the final packet of a source frame. Its arrival
+    // cadence is measured before jitter-buffer reassembly.
+    if (size >= 12 && (data[1] & 0x80u)) {
+        uint64_t arrived = SDL_GetPerformanceCounter();
+        if (self->diag_last_marker_counter_) {
+            record_cadence(
+                counter_delta_us(self->diag_last_marker_counter_, arrived),
+                self->diag_marker_lt25_, self->diag_marker_25_40_,
+                self->diag_marker_40_55_, self->diag_marker_55_75_,
+                self->diag_marker_gt75_, self->diag_marker_gap_max_us_);
+        }
+        self->diag_last_marker_counter_ = arrived;
+    }
     bool want_keyframe = false;
     self->jitter_.receive(
         data, size, SDL_GetTicks64(),
         [self](const uint8_t* au, size_t au_size) {
+            uint64_t emitted = SDL_GetPerformanceCounter();
+            if (self->diag_last_au_counter_) {
+                record_cadence(
+                    counter_delta_us(self->diag_last_au_counter_, emitted),
+                    self->diag_au_lt25_, self->diag_au_25_40_,
+                    self->diag_au_40_55_, self->diag_au_55_75_,
+                    self->diag_au_gt75_, self->diag_au_gap_max_us_);
+            }
+            self->diag_last_au_counter_ = emitted;
             {
                 std::lock_guard<std::mutex> lock(self->video_mutex_);
                 if (self->video_queue_.size() >= kMaxQueuedVideo)
-                    self->video_queue_.clear();
+                    self->video_queue_.clear(), self->video_queue_times_.clear();
                 self->video_queue_.emplace_back(au, au + au_size);
+                self->video_queue_times_.push_back(SDL_GetTicks64());
             }
             self->video_cv_.notify_one();  // wake the decode thread (Switch)
         },
@@ -580,7 +671,6 @@ void Engine::run_peer(GssvSession& session) {
         if (log_file_) {
             std::fprintf(log_file_, "----- OFFER -----\n%s\n----- ANSWER -----\n%s\n-----\n",
                          munged.c_str(), answer.c_str());
-            std::fflush(log_file_);
         }
     }
 
@@ -663,7 +753,6 @@ void Engine::run_peer(GssvSession& session) {
     }
     log("remote description set, checking connectivity");
 
-    Uint64 last_keepalive = SDL_GetTicks64();
     Uint64 last_rr = SDL_GetTicks64();
     Uint64 last_consent = SDL_GetTicks64();
     Uint64 last_audio_stats = SDL_GetTicks64();
@@ -676,6 +765,37 @@ void Engine::run_peer(GssvSession& session) {
     bool opened_channels = false;
     bool sent_handshake = false;
     PeerConnectionState last_logged_state = PEER_CONNECTION_NEW;
+
+    // GSSV keepalive is a blocking HTTPS request (with a timeout as high as
+    // 15 seconds). It must never run on this thread: this is also the sole
+    // libpeer socket pump, and pausing it lets the Switch's UDP receive queue
+    // overflow. In practice that produced a video/audio hitch followed by a
+    // PLI almost exactly every 15 seconds. Once signaling is complete, this
+    // helper is the only thread that uses `session`/its Http instance.
+    std::atomic<bool> keepalive_stop{false};
+    std::thread keepalive_thread([this, &session, &keepalive_stop] {
+        Uint64 next = SDL_GetTicks64() + 15000;
+        while (!quit_ && !keepalive_stop) {
+            Uint64 now = SDL_GetTicks64();
+            if (now < next) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(
+                    std::min<Uint64>(100, next - now)));
+                continue;
+            }
+            Uint64 started = now;
+            try {
+                session.keepalive();
+            } catch (const std::exception& error) {
+                if (!quit_ && !keepalive_stop)
+                    log(std::string("keepalive failed: ") + error.what());
+            }
+            Uint64 elapsed = SDL_GetTicks64() - started;
+            if (elapsed >= 100)
+                log("keepalive took " + std::to_string(elapsed) +
+                    "ms (off media thread)");
+            next = SDL_GetTicks64() + 15000;
+        }
+    });
 
     while (!quit_) {
         // Drain all packets ready on the socket this cycle. Video at 1080p is
@@ -718,12 +838,12 @@ void Engine::run_peer(GssvSession& session) {
 
         if (peer_state_ == PEER_CONNECTION_FAILED) {
             fail("WebRTC connection failed");
-            return;
+            break;
         }
         if (state_ == EngineState::Negotiating &&
             SDL_GetTicks64() - negotiation_started > 45000) {
             fail("Connection timed out");
-            return;
+            break;
         }
 
         // Until the first frame decodes, keep asking for a keyframe. xCloud may
@@ -784,6 +904,12 @@ void Engine::run_peer(GssvSession& session) {
             prev_audio_time = now;
             last_audio_stats = now;
             if (got_frame_) {
+                auto v = jitter_.stats();
+                size_t video_q = 0;
+                {
+                    std::lock_guard<std::mutex> lock(video_mutex_);
+                    video_q = video_queue_.size();
+                }
                 log("audio| rx=" + std::to_string(a.received) +
                     " play=" + std::to_string(a.played) +
                     " fail=" + std::to_string(a.failed) +
@@ -796,6 +922,77 @@ void Engine::run_peer(GssvSession& session) {
                     " dev=" + std::to_string(audio_.device_hz()) + "hz" +
                     " ema=" + std::to_string(a.ema_ms) + "ms" +
                     " adj=" + std::to_string(a.adj_ppm) + "ppm");
+                log("video| pkt=" + std::to_string(v.packets) +
+                    " frame=" + std::to_string(v.frames) +
+                    " lostfrm=" + std::to_string(v.dropped) +
+                    " nack=" + std::to_string(v.nacks) +
+                    " resync=" + std::to_string(v.resyncs) +
+                    " bytes=" + std::to_string(v.last_frame_bytes) +
+                    " q=" + std::to_string(video_q));
+#ifdef __SWITCH__
+                auto dk = dk_video_.take_timing_stats();
+                uint64_t dec_count =
+                    diag_decode_count_.exchange(0, std::memory_order_relaxed);
+                uint64_t dec_total =
+                    diag_decode_total_us_.exchange(0, std::memory_order_relaxed);
+                uint64_t handoff_total =
+                    diag_handoff_total_us_.exchange(0, std::memory_order_relaxed);
+                auto average = [](uint64_t total, uint64_t count) {
+                    return count ? total / count : 0;
+                };
+                log("timing| dec=" + std::to_string(dec_count) +
+                    " avg=" + std::to_string(average(dec_total, dec_count)) +
+                    "us max=" + std::to_string(
+                        diag_decode_max_us_.exchange(0, std::memory_order_relaxed)) +
+                    "us gapmax=" + std::to_string(
+                        diag_decode_gap_max_us_.exchange(0, std::memory_order_relaxed)) +
+                    "us qage=" + std::to_string(
+                        diag_queue_age_max_ms_.exchange(0, std::memory_order_relaxed)) +
+                    "ms lockavg=" +
+                    std::to_string(average(handoff_total, dec_count)) +
+                    "us lockmax=" + std::to_string(
+                        diag_handoff_max_us_.exchange(0, std::memory_order_relaxed)) +
+                    "us render=" + std::to_string(dk.renders) +
+                    " new=" + std::to_string(
+                        diag_present_new_.exchange(0, std::memory_order_relaxed)) +
+                    " repeat=" + std::to_string(
+                        diag_present_repeat_.exchange(0, std::memory_order_relaxed)) +
+                    " miss=" + std::to_string(
+                        diag_deadline_miss_.exchange(0, std::memory_order_relaxed)) +
+                    " late=" + std::to_string(
+                        diag_deadline_late_max_us_.exchange(
+                            0, std::memory_order_relaxed)) +
+                    "us acq=" + std::to_string(average(
+                        dk.acquire_total_us, dk.renders)) +
+                    "/" + std::to_string(dk.acquire_max_us) +
+                    "us present=" + std::to_string(average(
+                        dk.present_total_us, dk.renders)) +
+                    "/" + std::to_string(dk.present_max_us) +
+                    "us idle=" + std::to_string(average(
+                        dk.idle_total_us, dk.renders)) +
+                    "/" + std::to_string(dk.idle_max_us) + "us");
+                log("cadence| mark=" +
+                    std::to_string(diag_marker_lt25_.exchange(0)) + "/" +
+                    std::to_string(diag_marker_25_40_.exchange(0)) + "/" +
+                    std::to_string(diag_marker_40_55_.exchange(0)) + "/" +
+                    std::to_string(diag_marker_55_75_.exchange(0)) + "/" +
+                    std::to_string(diag_marker_gt75_.exchange(0)) +
+                    " max=" +
+                    std::to_string(diag_marker_gap_max_us_.exchange(0)) +
+                    "us au=" + std::to_string(diag_au_lt25_.exchange(0)) +
+                    "/" + std::to_string(diag_au_25_40_.exchange(0)) +
+                    "/" + std::to_string(diag_au_40_55_.exchange(0)) +
+                    "/" + std::to_string(diag_au_55_75_.exchange(0)) +
+                    "/" + std::to_string(diag_au_gt75_.exchange(0)) +
+                    " max=" + std::to_string(
+                        diag_au_gap_max_us_.exchange(0)) +
+                    "us hold=" + std::to_string(diag_hold_1_.exchange(0)) +
+                    "/" + std::to_string(diag_hold_2_.exchange(0)) +
+                    "/" + std::to_string(diag_hold_3_.exchange(0)) +
+                    "/" + std::to_string(diag_hold_4plus_.exchange(0)) +
+                    " skip=" + std::to_string(
+                        diag_surface_skipped_.exchange(0)));
+#endif
             }
         }
 
@@ -807,18 +1004,14 @@ void Engine::run_peer(GssvSession& session) {
             if (peer_) peer_connection_send_consent(peer_);
         }
 
-        if (now - last_keepalive > 15000) {
-            last_keepalive = now;
-            try {
-                session.keepalive();
-            } catch (const std::exception&) {}
-        }
-
         // Only yield when idle. While video is flowing we loop right back and
         // keep draining at full speed (the select() inside paces idle cycles).
         if (!drained_any)
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
+
+    keepalive_stop = true;
+    if (keepalive_thread.joinable()) keepalive_thread.join();
 }
 
 // ---- render-thread interface ----------------------------------------------
@@ -834,6 +1027,7 @@ void Engine::run_peer(GssvSession& session) {
 void Engine::decode_loop() {
     while (!quit_) {
         std::vector<uint8_t> unit;
+        Uint64 enqueued_at = 0;
         {
             std::unique_lock<std::mutex> lock(video_mutex_);
             video_cv_.wait_for(lock, std::chrono::milliseconds(20), [this] {
@@ -843,13 +1037,63 @@ void Engine::decode_loop() {
             if (video_queue_.empty()) continue;
             unit = std::move(video_queue_.front());
             video_queue_.pop_front();
+            if (!video_queue_times_.empty()) {
+                enqueued_at = video_queue_times_.front();
+                video_queue_times_.pop_front();
+            }
         }
+        if (enqueued_at)
+            atomic_max(diag_queue_age_max_ms_, SDL_GetTicks64() - enqueued_at);
+        uint64_t decode_started = SDL_GetPerformanceCounter();
         if (video_.decode(unit.data(), unit.size())) {
+            uint64_t decoded_at = SDL_GetPerformanceCounter();
+            uint64_t decode_us = counter_delta_us(decode_started, decoded_at);
+            diag_decode_count_.fetch_add(1, std::memory_order_relaxed);
+            diag_decode_total_us_.fetch_add(decode_us, std::memory_order_relaxed);
+            atomic_max(diag_decode_max_us_, decode_us);
+            uint64_t previous =
+                diag_last_decode_counter_.exchange(decoded_at,
+                                                   std::memory_order_relaxed);
+            if (previous) {
+                uint64_t gap_us = counter_delta_us(previous, decoded_at);
+                atomic_max(diag_decode_gap_max_us_,
+                           gap_us);
+                if (gap_us < 25000) {
+                    ++source_fast_streak_;
+                    source_slow_streak_ = 0;
+                    if (source_fast_streak_ >= 8) source_refresh_period_ = 1;
+                } else if (gap_us < 55000) {
+                    ++source_slow_streak_;
+                    source_fast_streak_ = 0;
+                    if (source_slow_streak_ >= 8) source_refresh_period_ = 2;
+                }
+            }
+            uint64_t handoff_started = SDL_GetPerformanceCounter();
             {
                 std::lock_guard<std::mutex> lock(frame_mutex_);
-                av_frame_unref(shared_frame_);
-                av_frame_ref(shared_frame_, video_.current_frame());
-                shared_frame_valid_ = true;
+                uint64_t locked_at = SDL_GetPerformanceCounter();
+                uint64_t handoff_us =
+                    counter_delta_us(handoff_started, locked_at);
+                diag_handoff_total_us_.fetch_add(handoff_us,
+                                                 std::memory_order_relaxed);
+                atomic_max(diag_handoff_max_us_, handoff_us);
+                ++shared_frame_seq_;
+                if (pacing_ == VideoPacing::Smooth) {
+                    AVFrame* queued = av_frame_clone(video_.current_frame());
+                    if (queued) smooth_frames_.push_back({queued, shared_frame_seq_});
+                    // Bound latency and NVTEGRA surface retention.
+                    while (smooth_frames_.size() > 4) {
+                        auto stale = smooth_frames_.front();
+                        smooth_frames_.pop_front();
+                        if (stale.frame) av_frame_free(&stale.frame);
+                        diag_surface_skipped_.fetch_add(1,
+                                                       std::memory_order_relaxed);
+                    }
+                } else {
+                    av_frame_unref(shared_frame_);
+                    av_frame_ref(shared_frame_, video_.current_frame());
+                    shared_frame_valid_ = true;
+                }
             }
             if (!got_frame_) {
                 got_frame_ = true;
@@ -874,25 +1118,89 @@ SDL_Texture* Engine::pump_video() {
     //    keeps a static / low-fps scene (e.g. a "syncing save" screen where
     //    xCloud nearly stops sending) from decaying to an empty surface -- which
     //    the YUV->RGB shader turns bright green.
-    // The rate is a hair UNDER 60 Hz on purpose: deko3d aborts (acquireImage ->
+    // Match the Switch display's NTSC-derived refresh. The old SDL_GetTicks64
+    // pacer quantized deadlines to whole milliseconds (uneven 16/17 ms spacing)
+    // and used 59.9 Hz, guaranteeing periodic repeats against a 60 fps stream.
+    // SDL's performance counter preserves the fractional deadline.
+    // The rate stays just under 60 Hz: deko3d aborts (acquireImage ->
     // DkResult_Fail) if we queue frames faster than the compositor drains them.
     // We take our OWN ref of the shared frame so the decode thread can keep
     // producing without recycling the surface the GPU is still sampling.
-    constexpr double kPresentIntervalMs = 1000.0 / 59.9;  // ~16.69 ms
-    double now = static_cast<double>(SDL_GetTicks64());
-    if (dk_video_.initialized() && got_frame_ && now >= next_present_ms_) {
+    constexpr double kDisplayHz = 59.94;
+    const double interval =
+        static_cast<double>(SDL_GetPerformanceFrequency()) / kDisplayHz;
+    double now = static_cast<double>(SDL_GetPerformanceCounter());
+    if (dk_video_.initialized() && got_frame_ &&
+        now >= next_present_counter_) {
         AVFrame* frame = nullptr;
+        uint64_t frame_seq = 0;
         {
             std::lock_guard<std::mutex> lock(frame_mutex_);
-            if (shared_frame_valid_) {
+            if (pacing_ == VideoPacing::Smooth) {
+                uint32_t period =
+                    source_refresh_period_.load(std::memory_order_relaxed);
+                bool due = !smooth_have_present_ ||
+                           ++smooth_refresh_phase_ >= period;
+                // Keep one decoded frame in reserve to absorb arrival jitter.
+                if (due && smooth_frames_.size() >= 2) {
+                    SmoothFrame next = smooth_frames_.front();
+                    smooth_frames_.pop_front();
+                    av_frame_unref(present_frame_);
+                    av_frame_move_ref(present_frame_, next.frame);
+                    av_frame_free(&next.frame);
+                    frame_seq = next.seq;
+                    smooth_have_present_ = true;
+                    smooth_refresh_phase_ = 0;
+                } else if (smooth_have_present_) {
+                    frame_seq = last_present_seq_;
+                }
+                if (smooth_have_present_) frame = present_frame_;
+            } else if (shared_frame_valid_) {
                 av_frame_unref(present_frame_);
                 if (av_frame_ref(present_frame_, shared_frame_) == 0)
                     frame = present_frame_;
+                frame_seq = shared_frame_seq_;
             }
         }
-        if (frame) dk_video_.render(frame);
-        next_present_ms_ += kPresentIntervalMs;
-        if (next_present_ms_ < now) next_present_ms_ = now + kPresentIntervalMs;
+        if (frame) {
+            if (frame_seq != last_present_seq_) {
+                diag_present_new_.fetch_add(1, std::memory_order_relaxed);
+                if (last_present_seq_) {
+                    if (present_hold_refreshes_ == 1)
+                        diag_hold_1_.fetch_add(1, std::memory_order_relaxed);
+                    else if (present_hold_refreshes_ == 2)
+                        diag_hold_2_.fetch_add(1, std::memory_order_relaxed);
+                    else if (present_hold_refreshes_ == 3)
+                        diag_hold_3_.fetch_add(1, std::memory_order_relaxed);
+                    else if (present_hold_refreshes_ >= 4)
+                        diag_hold_4plus_.fetch_add(1,
+                                                  std::memory_order_relaxed);
+                    if (frame_seq > last_present_seq_ + 1)
+                        diag_surface_skipped_.fetch_add(
+                            frame_seq - last_present_seq_ - 1,
+                            std::memory_order_relaxed);
+                }
+                last_present_seq_ = frame_seq;
+                present_hold_refreshes_ = 1;
+            } else {
+                diag_present_repeat_.fetch_add(1, std::memory_order_relaxed);
+                ++present_hold_refreshes_;
+            }
+            double lateness = now - next_present_counter_;
+            if (lateness >= interval) {
+                diag_deadline_miss_.fetch_add(1, std::memory_order_relaxed);
+                uint64_t frequency = SDL_GetPerformanceFrequency();
+                uint64_t late_us = frequency
+                    ? static_cast<uint64_t>(lateness * 1000000.0 /
+                                            static_cast<double>(frequency))
+                    : 0;
+                atomic_max(diag_deadline_late_max_us_, late_us);
+            }
+            dk_video_.render(frame);
+        }
+        next_present_counter_ += interval;
+        if (next_present_counter_ < now)
+            next_present_counter_ = now + interval;
     }
     return nullptr;
 #else
@@ -905,6 +1213,7 @@ SDL_Texture* Engine::pump_video() {
             if (video_queue_.empty()) break;
             unit = std::move(video_queue_.front());
             video_queue_.pop_front();
+            if (!video_queue_times_.empty()) video_queue_times_.pop_front();
         }
         if (video_.decode(unit.data(), unit.size()) && !got_frame_) {
             got_frame_ = true;
@@ -919,6 +1228,8 @@ SDL_Texture* Engine::pump_video() {
 bool Engine::begin_deko_output() {
 #ifdef __SWITCH__
     dk_video_.set_logger([this](const char* m) { log(std::string(m)); });
+    dk_video_.set_sharpness(sharpness_);
+    dk_video_.set_contrast(contrast_);
     bool ok = dk_video_.init();
     log(ok ? "deko3d output started" : "deko3d output FAILED to start");
     return ok;

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -38,6 +38,8 @@ enum class EngineState {
     Stopped,
 };
 
+enum class VideoPacing { LowLatency = 0, Smooth = 1 };
+
 // Native xCloud streaming session: GSSV signaling + libpeer WebRTC +
 // NVDEC/SDL video + Opus audio + gamepad input channel.
 class Engine {
@@ -46,7 +48,9 @@ public:
     ~Engine();
 
     void start(const std::string& title_id, QualityTier tier,
-               const std::string& locale = "en-US");
+               const std::string& locale = "en-US",
+               VideoPacing pacing = VideoPacing::LowLatency,
+               int sharpness = 2, int contrast = 0);
     void stop();
 
     EngineState state() const { return state_; }
@@ -118,6 +122,9 @@ private:
     std::string title_id_;
     QualityTier tier_ = QualityTier::P1080HQ;
     std::string locale_ = "en-US";  // streamed console's system language
+    VideoPacing pacing_ = VideoPacing::LowLatency;
+    int sharpness_ = 2;
+    int contrast_ = 0;
 public:
     void log(const std::string& line);  // also used by the libpeer log sink
 
@@ -141,6 +148,7 @@ private:
     std::mutex video_mutex_;
     std::condition_variable video_cv_;  // wakes decode_loop when an AU arrives
     std::deque<std::vector<uint8_t>> video_queue_;
+    std::deque<Uint64> video_queue_times_;  // enqueue time matching each AU
     std::atomic<bool> got_frame_{false};
 
     // Decoded-frame handoff (Switch): decode_thread_ decodes into shared_frame_;
@@ -152,6 +160,48 @@ private:
     AVFrame* shared_frame_ = nullptr;   // latest decoded (decode thread writes)
     AVFrame* present_frame_ = nullptr;  // render thread's stable ref
     bool shared_frame_valid_ = false;
+    uint64_t shared_frame_seq_ = 0;     // protected by frame_mutex_
+    uint64_t last_present_seq_ = 0;     // render thread only
+    uint32_t present_hold_refreshes_ = 0;
+    struct SmoothFrame {
+        AVFrame* frame = nullptr;
+        uint64_t seq = 0;
+    };
+    std::deque<SmoothFrame> smooth_frames_;  // protected by frame_mutex_
+    bool smooth_have_present_ = false;
+    uint32_t smooth_refresh_phase_ = 0;
+    std::atomic<uint32_t> source_refresh_period_{1};  // 1=60fps, 2=30fps
+    uint32_t source_fast_streak_ = 0;  // decode thread only
+    uint32_t source_slow_streak_ = 0;  // decode thread only
+
+    // Diagnostic-only aggregate timings. These do not alter media behavior.
+    std::atomic<uint64_t> diag_decode_count_{0};
+    std::atomic<uint64_t> diag_decode_total_us_{0};
+    std::atomic<uint64_t> diag_decode_max_us_{0};
+    std::atomic<uint64_t> diag_handoff_total_us_{0};
+    std::atomic<uint64_t> diag_handoff_max_us_{0};
+    std::atomic<uint64_t> diag_queue_age_max_ms_{0};
+    std::atomic<uint64_t> diag_present_new_{0};
+    std::atomic<uint64_t> diag_present_repeat_{0};
+    std::atomic<uint64_t> diag_deadline_miss_{0};
+    std::atomic<uint64_t> diag_deadline_late_max_us_{0};
+    std::atomic<uint64_t> diag_last_decode_counter_{0};
+    std::atomic<uint64_t> diag_decode_gap_max_us_{0};
+
+    // Source and display cadence. Marker timing shows raw RTP delivery, AU
+    // timing shows completed jitter-buffer output, and hold buckets show how
+    // many display refreshes each decoded surface remained visible.
+    uint64_t diag_last_marker_counter_ = 0;  // worker thread only
+    uint64_t diag_last_au_counter_ = 0;      // worker thread only
+    std::atomic<uint64_t> diag_marker_lt25_{0}, diag_marker_25_40_{0};
+    std::atomic<uint64_t> diag_marker_40_55_{0}, diag_marker_55_75_{0};
+    std::atomic<uint64_t> diag_marker_gt75_{0}, diag_marker_gap_max_us_{0};
+    std::atomic<uint64_t> diag_au_lt25_{0}, diag_au_25_40_{0};
+    std::atomic<uint64_t> diag_au_40_55_{0}, diag_au_55_75_{0};
+    std::atomic<uint64_t> diag_au_gt75_{0}, diag_au_gap_max_us_{0};
+    std::atomic<uint64_t> diag_hold_1_{0}, diag_hold_2_{0};
+    std::atomic<uint64_t> diag_hold_3_{0}, diag_hold_4plus_{0};
+    std::atomic<uint64_t> diag_surface_skipped_{0};
 
     xcloud::InputSerializer input_;
     std::mutex input_mutex_;
@@ -163,8 +213,8 @@ private:
     bool rumble_pending_ = false;
     bool rumble_logged_ = false;  // peer thread only: log the first report once
     Uint64 stream_epoch_ = 0;
-    // Render-thread software vsync pacer for the deko3d present (see pump_video).
-    double next_present_ms_ = 0;
+    // High-resolution render deadline in SDL performance-counter ticks.
+    double next_present_counter_ = 0;
     std::atomic<Uint64> last_keyframe_req_{0};
     std::atomic<uint32_t> pli_sent_{0};  // RTCP PLI keyframe requests
 

--- a/src/switch/stream/video_jitter.cpp
+++ b/src/switch/stream/video_jitter.cpp
@@ -8,8 +8,11 @@ namespace gnx::stream {
 namespace {
 
 constexpr size_t kMaxAccessUnitBytes = 2 * 1024 * 1024;
-constexpr uint64_t kHoldMs = 90;   // hold an incomplete frame this long for
-                                   // retransmit/reorder before giving up
+// Allow enough time for a NACK round trip on a distant xCloud route. At 90 ms,
+// a single video packet arriving just after the deadline discarded the whole
+// predictive chain and froze output until a new IDR. The added delay applies
+// only while a frame is already incomplete; healthy frames still emit at once.
+constexpr uint64_t kHoldMs = 200;
 constexpr size_t kMaxFrames = 32;  // safety cap on buffered frames
 const uint8_t kStartCode[4] = {0x00, 0x00, 0x00, 0x01};
 
@@ -109,6 +112,7 @@ void VideoJitterBuffer::reset() {
     frames_.clear();
     last_ts_.reset();
     waiting_keyframe_ = true;
+    stats_ = {};
     have_seq_ = false;
     max_seq_ = 0;
     cycles_ = base_seq_ = received_ = received_prior_ = expected_prior_ = 0;


### PR DESCRIPTION
## Main result: remove recurring stream stalls and reduce visible hitching

This PR primarily addresses the recurring stutter observed during real xCloud
sessions on a Nintendo Switch V1. Instrumentation and captured stream logs
identified two original media-thread stalls plus a separate presentation
cadence problem.

### Primary stutter causes fixed

1. **Synchronous SD-card log flushing**

   Every `log()` call performed `fflush()`. The once-per-second audio statistics
   line therefore forced a synchronous SD-card write on the same thread that
   pumps libpeer networking. Depending on SD-card latency, this produced small,
   regular video hitches.

   The fix removes per-line flushing, gives the session log a 256 KiB memory
   buffer, and lets `fclose()` flush it during a clean stream shutdown.

2. **Blocking GSSV keepalive on the media thread**

   `session.keepalive()` performed a blocking HTTPS request on the sole libpeer
   socket-pump thread, with a timeout as high as 15 seconds. While it was
   blocked, RTP processing stopped, the Switch UDP receive queue could overflow,
   and the result was a video/audio hitch followed by a PLI—often at an
   approximately 15-second interval.

   The fix moves keepalive work to a separate thread so signaling latency cannot
   pause RTP, audio or video processing.

3. **Uneven source/presentation cadence**

   After the blocking stalls were removed, smaller motion hitches remained.
   xCloud frequently changed to a 30 FPS source cadence and delivered frames
   with uneven arrival timing. The old millisecond presentation pacer also
   alternated coarse 16/17 ms deadlines. Presenting the newest frame immediately
   exposed that timing as uneven one-, two- and three-refresh holds on the
   Switch's 60 Hz display.

   The new **Smooth** mode keeps one decoded source frame in reserve and presents
   it on a controlled 30/60 Hz cadence. Captured-session comparisons reduced
   non-two-refresh holds from roughly **15% in Low latency mode to 0.4% in
   Smooth mode**—about a **97% reduction in client-side cadence irregularity**.

> [!IMPORTANT]
> Choose **Low latency** for the best controller response. It presents the
> newest decoded frame immediately and preserves the original latency-first
> behavior.
>
> Choose **Smooth** for steadier motion. It intentionally adds approximately
> one source frame of delay—about **33 ms when xCloud supplies 30 FPS**—to
> absorb arrival jitter.

These fixes cannot prevent a true server, Wi-Fi or packet-loss stall, but they
remove avoidable client-side blocking and stop normal arrival jitter from being
exposed directly as repeated motion hitches.

The work was developed from commit `b80b9b9` using baseline, diagnostic,
cadence, low-latency and smooth logs captured on real Switch hardware.

## What changed

### Stream pacing and diagnostics

- Add **Low latency** and **Smooth** pacing choices.
- Detect whether the source currently behaves as 30 or 60 FPS.
- Replace millisecond presentation pacing with high-resolution deadlines.
- Track RTP marker arrival, completed access units, queue age, decode, handoff,
  render, GPU acquire/present/idle time, deadline misses, skipped surfaces and
  displayed-frame hold cadence.
- Keep separate current/previous diagnostic logs for each behavior:
  - `stream-log-low-latency.txt`
  - `stream-log-smooth.txt`
- Log cadence distributions so future hitches can be separated into source,
  network, decode and presentation causes.
- Keep decode work bounded instead of allowing stale frames to grow latency.

`deko3d`'s synchronous `queue_.waitIdle()` was also instrumented because it was
an early suspect. Captured timings were normally approximately 0.7–9 ms, so it
was not identified as the primary recurring hitch source.

### Image enhancement

- Add luma-only sharpening with **Off**, **Low**, **Medium**, **High** and
  **Extreme** strengths.
- Keep chroma untouched and use overshoot limits to control halos.
- Add endpoint-protected contrast enhancement with **Off**, **Low**,
  **Medium** and **High** strengths.
- Add independent three-second sharpening and contrast **Strobe tests**.
- Display the active Strobe level in the top-left of the stream.
- Keep sharpening and contrast labels on separate lines and correct their
  orientation.
- Persist pacing, sharpening and contrast selections in `settings.json`.
- Recommend Medium for sharpening and contrast in Settings while explaining
  Off and both Strobe comparison modes.
### How to use the Strobe tests

Strobe is a temporary visual comparison tool, not the recommended normal
playback setting.

1. From the library, press **ZL** to open **Settings**.
2. Highlight **Luma sharpening** or **Contrast**.
3. Press Left/Right until the selected control reads **Strobe test**.
4. Return to the library, launch a game, and watch the top-left overlay.
5. Observe the same fine detail, text and moving edges for one complete cycle.
6. Return to Settings and select the fixed level that looked best.

The sharpening Strobe changes every three seconds through:

**Off → Low → Medium → High → Extreme → repeat**

The contrast Strobe changes every three seconds through:

**Off → Low → Medium → High → repeat**

The active level is labeled in the top-left of the game stream. Sharpening and
contrast use separate overlay lines, so both Strobe tests may be enabled at the
same time without their labels overlapping. Medium is the recommended starting
point for both fixed settings; use Off if the original xCloud image is
preferred or if sharpening makes compression edges look harsh.

### Audio/session reliability

- Reset the audio RTP jitter buffer, inbox and playback counters for every
  stream.
- Prevent a previous stream's RTP sequence state from causing silence after
  reconnecting or switching pacing modes in the same app session.

### Build, logging and documentation

- Make the dependency smoke test provide application-owned Switch hooks.
- Apply the libpeer patch without invalid dirty-submodule gitlink entries.
- Prevent MSYS path conversion from corrupting Docker volume paths on Windows.
- Remove a high-frequency RTCP sender-report log line.
- Add a changelog and expand installation, Settings, Strobe, logging and build
  documentation.
- Exclude local safety snapshots.
- Keep test logs, NRO/ELF/NACP files, build output and safety copies out of the
  PR.

## User impact

- Select **Low latency** when controller responsiveness is the priority.
- Select **Smooth** when consistent motion is the priority and one additional
  source frame of latency is acceptable.
- Adjust sharpening and contrast from the UI without rebuilding.
- Diagnose any remaining hitch using separate per-mode timing and cadence logs.
- Restart or change streams in the same process without losing audio.

## Validation

- Built successfully with `devkitpro/devkita64`.
- Verified a clean incremental build: `Nothing to be done for 'all'`.
- Shader compilation and NRO packaging completed successfully.
- `git diff --check` passes.
- Tested through multiple real xCloud sessions with baseline, diagnostic,
  cadence, low-latency and smooth logs.
- A repeat build immediately before publishing could not start because Docker
  Desktop was not running. No functional source changed after the successful
  build; only the README heading was made version-neutral.

## Integration note

This branch intentionally starts at `b80b9b9`. Upstream `main` advanced after
that point and independently contains the audio reset and clean-clone build
work. The maintainer may rebase, resolve the overlapping hunks, or cherry-pick
the media-thread, pacing and image-enhancement portions during review.
