### PR TITLE
feat(audio): adjustable output volume + soft-knee limiter

### DIFF
--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -1169,6 +1169,8 @@ void draw_settings(App& app) {
         {"Vibration", kVibrationLabels[app.settings.vibration]},
         {"Region bypass", kRegionLabels[app.settings.region]},
         {"Game language", kLanguageLabels[app.settings.language]},
+        {"Volume",
+         std::to_string(static_cast<int>(app.settings.volume * 100 + 0.5f)) + "%"},
     };
     if (!app.consoles.empty())
         rows.push_back({"Preferred source",
@@ -1181,11 +1183,14 @@ void draw_settings(App& app) {
     rows.push_back({"Sign out", app.signout_armed
                                     ? "Press A again to confirm"
                                     : app.gamertag});
-    // 7 rows (console linked + sign out) must still clear the note box at
-    // y=820, so the row pitch tightens once the list grows past 6.
-    int pitch = rows.size() <= 6 ? 108 : 92;
+    // The list must clear the note box at y=820. The Volume row can push it to
+    // 8 rows (console linked + volume + sign out), so the pitch tightens (and
+    // the rows shrink to match, so they never overlap) past 7. Up to 7 keeps the
+    // original 108/92 look.
+    int pitch = rows.size() <= 6 ? 108 : rows.size() <= 7 ? 92 : 78;
+    int row_h = rows.size() <= 7 ? 96 : 70;
     for (int i = 0; i < static_cast<int>(rows.size()); ++i) {
-        SDL_Rect row = {120, 170 + i * pitch, gfx::kWidth - 240, 96};
+        SDL_Rect row = {120, 170 + i * pitch, gfx::kWidth - 240, row_h};
         bool focused = i == app.settings_cursor;
         // Row-focus variant (card 1g): wide elements don't scale — surface
         // lift + 10px side bar + 4px border + one glow frame instead.
@@ -1231,6 +1236,10 @@ void draw_settings(App& app) {
         line2 = "the saved sign-in. Cloud saves and games are not affected.";
     } else switch (app.settings_cursor) {
         case 5:
+            line1 = "Output volume for streamed audio — raise it if the stream";
+            line2 = "sounds quiet even with the console at full volume.";
+            break;
+        case 6:
             line1 = "Where Play launches games: xCloud (cloud servers) or";
             line2 = "remote play from your own console over your network.";
             break;
@@ -1864,7 +1873,9 @@ int main(int argc, char** argv) {
             }
 
             case Scene::Settings: {
-                int signout_row = app.consoles.empty() ? 5 : 6;
+                // +1 vs upstream: the Volume row sits before "Preferred source"
+                // and "Sign out", pushing the last row down by one.
+                int signout_row = app.consoles.empty() ? 6 : 7;
                 if (input.up)
                     app.settings_cursor = std::max(0, app.settings_cursor - 1);
                 if (input.down)
@@ -1909,6 +1920,9 @@ int main(int argc, char** argv) {
                         app.settings.language =
                             (app.settings.language + direction + kLanguageCount) %
                             kLanguageCount;
+                    else if (app.settings_cursor == 5)
+                        app.settings.volume = std::clamp(
+                            app.settings.volume + direction * 0.5f, 0.5f, 4.0f);
                     else
                         app.settings.source =
                             (app.settings.source + direction + 3) % 3;

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -141,6 +141,7 @@ struct Settings {
     int region = 0;     // region-bypass IP: 0=Off, else index into kRegion*
     int language = 0;   // index into kLanguage* (0 = English US)
     int source = 0;     // 0=ask every time, 1=xCloud, 2=your Xbox
+    float volume = 2.0f;  // output gain for streamed audio (0.5-4.0); tune in settings.json
 };
 
 constexpr int kLanguageCount = 14;
@@ -221,6 +222,7 @@ Settings load_settings() {
     settings.language =
         std::clamp(data.value("language", 0), 0, kLanguageCount - 1);
     settings.source = std::clamp(data.value("source", 0), 0, 2);
+    settings.volume = std::clamp(data.value("volume", 2.0f), 0.5f, 4.0f);
     return settings;
 }
 
@@ -231,7 +233,8 @@ void save_settings(const Settings& settings) {
                 {"vibration", settings.vibration},
                 {"region", settings.region},
                 {"language", settings.language},
-                {"source", settings.source}}.dump(2);
+                {"source", settings.source},
+                {"volume", settings.volume}}.dump(2);
 }
 
 // Streamed console's system language (BCP-47). Games without an in-game
@@ -789,6 +792,7 @@ void launch_stream(App& app, bool home) {
 #ifdef GNX_NATIVE_STREAM
     QualityTier tier = static_cast<QualityTier>(app.settings.quality);
     const char* locale = kLanguageCodes[app.settings.language];
+    app.engine->set_audio_gain(app.settings.volume);
     if (app.launching_home)
         app.engine->start_home(selected_console(app).server_id, tier, locale);
     else

--- a/src/switch/stream/audio_player.cpp
+++ b/src/switch/stream/audio_player.cpp
@@ -143,17 +143,28 @@ void AudioPlayer::thread_main() {
                               std::memory_order_relaxed);
             played_.fetch_add(1, std::memory_order_relaxed);
 
-            // Output-volume gain: xCloud/console audio plays quiet at unity, so
-            // lift the decoded PCM before it enters the ring (clamped to the
-            // int16 rails). A cheap per-sample multiply; unity is a no-op.
+            // Output-volume gain + soft-knee limiter. xCloud/console audio plays
+            // quiet at unity, so we lift it; but a hard clip at high gain
+            // distorts loud passages. Everything below the knee stays perfectly
+            // linear (normal audio is untouched); only peaks above the knee are
+            // compressed smoothly toward full scale, so higher volumes stay
+            // clean instead of clipping. `over/(over+headroom)` maps the
+            // overshoot into the remaining headroom, so |out| never reaches the
+            // rail. A cheap per-sample op; unity gain is a no-op.
             float gain = gain_.load(std::memory_order_relaxed);
             if (gain != 1.0f) {
+                constexpr float kKnee = 24000.0f;               // ~ -2.7 dBFS
+                constexpr float kHeadroom = 32767.0f - kKnee;   // 8767
                 const int total = samples * kChannels;
                 for (int i = 0; i < total; ++i) {
-                    int v = static_cast<int>(pcm_[i] * gain);
-                    pcm_[i] = v > 32767    ? 32767
-                              : v < -32768 ? -32768
-                                           : static_cast<int16_t>(v);
+                    float s = pcm_[i] * gain;
+                    float a = s < 0.0f ? -s : s;
+                    if (a > kKnee) {
+                        float over = a - kKnee;
+                        a = kKnee + kHeadroom * (over / (over + kHeadroom));
+                        s = s < 0.0f ? -a : a;
+                    }
+                    pcm_[i] = static_cast<int16_t>(s);
                 }
             }
 

--- a/src/switch/stream/audio_player.cpp
+++ b/src/switch/stream/audio_player.cpp
@@ -143,6 +143,20 @@ void AudioPlayer::thread_main() {
                               std::memory_order_relaxed);
             played_.fetch_add(1, std::memory_order_relaxed);
 
+            // Output-volume gain: xCloud/console audio plays quiet at unity, so
+            // lift the decoded PCM before it enters the ring (clamped to the
+            // int16 rails). A cheap per-sample multiply; unity is a no-op.
+            float gain = gain_.load(std::memory_order_relaxed);
+            if (gain != 1.0f) {
+                const int total = samples * kChannels;
+                for (int i = 0; i < total; ++i) {
+                    int v = static_cast<int>(pcm_[i] * gain);
+                    pcm_[i] = v > 32767    ? 32767
+                              : v < -32768 ? -32768
+                                           : static_cast<int16_t>(v);
+                }
+            }
+
             // Steer the servo on smoothed ring depth, then stretch/shrink
             // this frame accordingly before it enters the ring.
             float depth_ms;

--- a/src/switch/stream/audio_player.hpp
+++ b/src/switch/stream/audio_player.hpp
@@ -43,6 +43,10 @@ public:
 
     int device_hz() const { return device_hz_; }
 
+    // Output volume multiplier applied to decoded PCM (1.0 = unchanged). Safe to
+    // call from any thread; the decode thread reads it per frame.
+    void set_gain(float gain) { gain_.store(gain, std::memory_order_relaxed); }
+
     // Diagnostic telemetry (cumulative unless noted).
     struct Stats {
         uint32_t received = 0;     // packets handed to submit()
@@ -74,6 +78,7 @@ private:
 
     OpusDecoder* decoder_ = nullptr;
     int device_hz_ = 0;
+    std::atomic<float> gain_{1.0f};  // output volume multiplier (set_gain)
     bool audout_up_ = false;
     void* out_mem_[kNumOutBufs] = {};
     AudioOutBuffer out_bufs_[kNumOutBufs] = {};

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -160,6 +160,7 @@ void Engine::start_common(const std::string& title_id, QualityTier tier,
     state_ = EngineState::StartingSession;
     video_.init(renderer_);
     audio_.init();
+    audio_.set_gain(audio_gain_);
 #ifdef __SWITCH__
     shared_frame_ = av_frame_alloc();
     present_frame_ = av_frame_alloc();

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -53,6 +53,10 @@ public:
                     const std::string& locale = "en-US");
     void stop();
 
+    // Output gain applied to decoded audio (forwarded to the AudioPlayer). Set
+    // from the "volume" setting before each stream start; 1.0 = unchanged.
+    void set_audio_gain(float gain) { audio_gain_ = gain; }
+
     EngineState state() const { return state_; }
     std::string status() const;
     std::string error() const;
@@ -129,6 +133,7 @@ private:
     std::string home_server_id_;  // non-empty selects the home (xhome) path
     QualityTier tier_ = QualityTier::P1080HQ;
     std::string locale_ = "en-US";  // streamed console's system language
+    float audio_gain_ = 1.0f;       // forwarded to AudioPlayer::set_gain
 public:
     void log(const std::string& line);  // also used by the libpeer log sink
 


### PR DESCRIPTION
Streamed audio can sound quiet even with the console at full volume. This adds an output gain on the decoded audio, adjustable two ways:

- A **Volume** row in Settings (◀ ▶, 50%–400%).
- A `"volume"` key in `settings.json`, for tuning without recompiling.

A **soft-knee limiter** replaces the hard clip on the boosted signal, so raising the gain rounds off peaks instead of clipping them harshly.

The Volume row can push Settings to 8 rows (console linked + volume + sign out), so the row pitch tightens past 7 rows to keep the last one clear of the note box — the ≤7-row layout is unchanged.

Scope: audio player + engine gain plumbing + one Settings row. Builds clean from a fresh clone.
