### PR TITLE
feat(hud): on-screen debug overlay (resolution, FPS, bitrate, loss)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,8 @@ export NROFLAGS += --icon=$(CURDIR)/$(APP_ICON) --nacp=$(CURDIR)/$(TARGET).nacp
 # deko3d shaders: compiled from GLSL to .dksh with uam and shipped in romfs.
 UAM        := $(DEVKITPRO)/tools/bin/uam
 SHADER_OUT := $(CURDIR)/romfs/shaders/video_vsh.dksh \
-              $(CURDIR)/romfs/shaders/video_fsh.dksh
+              $(CURDIR)/romfs/shaders/video_fsh.dksh \
+              $(CURDIR)/romfs/shaders/hud_fsh.dksh
 
 .PHONY: all clean shaders
 

--- a/shaders/hud_fsh.glsl
+++ b/shaders/hud_fsh.glsl
@@ -1,0 +1,12 @@
+#version 460
+
+// HUD overlay fragment shader. Stage 0: a flat semi-transparent panel to prove
+// the overlay pass + alpha blending work over the video. Stage 1 samples a text
+// texture here instead.
+layout (location = 0) in vec2 vTextureCoord;
+layout (location = 0) out vec4 outColor;
+
+void main()
+{
+    outColor = vec4(0.0, 0.0, 0.0, 0.55);
+}

--- a/shaders/hud_fsh.glsl
+++ b/shaders/hud_fsh.glsl
@@ -1,12 +1,15 @@
 #version 460
 
-// HUD overlay fragment shader. Stage 0: a flat semi-transparent panel to prove
-// the overlay pass + alpha blending work over the video. Stage 1 samples a text
-// texture here instead.
+// HUD overlay fragment shader. Stage 1: sample the rasterized HUD texture (the
+// semi-transparent panel background + white stats text, composited on the CPU)
+// and emit it straight through -- the pass is alpha-blended over the video, so
+// the texture's own alpha controls the overlay.
 layout (location = 0) in vec2 vTextureCoord;
 layout (location = 0) out vec4 outColor;
 
+layout (binding = 0) uniform sampler2D hudtex;
+
 void main()
 {
-    outColor = vec4(0.0, 0.0, 0.0, 0.55);
+    outColor = texture(hudtex, vTextureCoord);
 }

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -147,7 +147,7 @@ struct Settings {
     // extra latency ("Video pacing" row / "smooth" in settings.json).
     bool smooth = false;
     int sharpness = 0;  // luma sharpening: 0=Off, 1=Low, 2=Medium, 3=High
-    int debug_hud = 1;  // 0=off, 1=on: on-screen debug overlay while streaming
+    int debug_hud = 0;  // 0=off, 1=on: on-screen debug overlay while streaming
 };
 
 constexpr int kLanguageCount = 14;
@@ -283,7 +283,7 @@ Settings load_settings() {
     settings.volume = std::clamp(data.value("volume", 1.0f), 0.5f, 4.0f);
     settings.smooth = data.value("smooth", false);
     settings.sharpness = std::clamp(data.value("sharpness", 0), 0, 3);
-    settings.debug_hud = std::clamp(data.value("debug_hud", 1), 0, 1);
+    settings.debug_hud = std::clamp(data.value("debug_hud", 0), 0, 1);
     return settings;
 }
 

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -147,6 +147,7 @@ struct Settings {
     // extra latency ("Video pacing" row / "smooth" in settings.json).
     bool smooth = false;
     int sharpness = 0;  // luma sharpening: 0=Off, 1=Low, 2=Medium, 3=High
+    int debug_hud = 1;  // 0=off, 1=on: on-screen debug overlay while streaming
 };
 
 constexpr int kLanguageCount = 14;
@@ -282,6 +283,7 @@ Settings load_settings() {
     settings.volume = std::clamp(data.value("volume", 1.0f), 0.5f, 4.0f);
     settings.smooth = data.value("smooth", false);
     settings.sharpness = std::clamp(data.value("sharpness", 0), 0, 3);
+    settings.debug_hud = std::clamp(data.value("debug_hud", 1), 0, 1);
     return settings;
 }
 
@@ -295,7 +297,8 @@ void save_settings(const Settings& settings) {
                 {"source", settings.source},
                 {"volume", settings.volume},
                 {"smooth", settings.smooth},
-                {"sharpness", settings.sharpness}}.dump(2);
+                {"sharpness", settings.sharpness},
+                {"debug_hud", settings.debug_hud}}.dump(2);
 }
 
 // Streamed console's system language (BCP-47). Games without an in-game
@@ -860,6 +863,7 @@ void launch_stream(App& app, bool home) {
     app.engine->set_pacing(app.settings.smooth ? stream::VideoPacing::Smooth
                                                : stream::VideoPacing::Steady);
     app.engine->set_sharpness(app.settings.sharpness);
+    app.engine->set_debug_hud(app.settings.debug_hud != 0);
     if (app.launching_home)
         app.engine->start_home(selected_console(app).server_id, tier, locale);
     else
@@ -1246,6 +1250,7 @@ void draw_settings(App& app) {
                         app.settings.source == 2   ? console_label(app)
                         : app.settings.source == 1 ? "xCloud"
                                                    : "Ask every time"});
+    rows.push_back({"Debug HUD", app.settings.debug_hud ? "On" : "Off"});
     // Sign out lives here rather than on a library shoulder button so a stray
     // press can never log the account out; it also takes a second A to confirm.
     int signout_row = static_cast<int>(rows.size());
@@ -1253,10 +1258,10 @@ void draw_settings(App& app) {
                                     ? "Press A again to confirm"
                                     : app.gamertag});
     // The list must clear the note box at y=820, which fits 8 rows at the
-    // tightened 78/70 pitch. A linked console now makes 9 (volume + pacing +
-    // source + sign out), so instead of shrinking rows a third time the list
-    // scrolls: an 8-row window slides only when the cursor crosses its edge,
-    // and dots mark hidden rows. Up to 7 rows keeps the original 108/92 look.
+    // tightened 78/70 pitch. Volume + pacing + Debug HUD (+ source + sign out on
+    // a linked console) overflow that, so instead of shrinking rows further the
+    // list scrolls: an 8-row window slides only when the cursor crosses its
+    // edge, and dots mark hidden rows. Up to 7 rows keeps the original 108/92.
     constexpr int kVisibleRows = 8;
     int shown = std::min(static_cast<int>(rows.size()), kVisibleRows);
     int first = std::clamp(app.settings_cursor - (kVisibleRows - 1), 0,
@@ -1316,6 +1321,9 @@ void draw_settings(App& app) {
     if (app.settings_cursor == signout_row) {
         line1 = "Signs this Switch out of your Microsoft account and clears";
         line2 = "the saved sign-in. Cloud saves and games are not affected.";
+    } else if (app.settings_cursor == signout_row - 1) {
+        line1 = "On-screen overlay with live stream stats (resolution, FPS,";
+        line2 = "bitrate, loss). A debug tool -- turn it off for clean playback.";
     } else switch (app.settings_cursor) {
         case 5:
             line1 = "Output volume for streamed audio — raise it if the stream";
@@ -2138,9 +2146,9 @@ int main(int argc, char** argv) {
 
             case Scene::Settings: {
                 // Row order: quality, mapping, vibration, region, language,
-                // volume, pacing, sharpness, [source when a console is
-                // linked], sign out.
-                int signout_row = app.consoles.empty() ? 8 : 9;
+                // volume, pacing, sharpness, [source when a console is linked],
+                // Debug HUD, sign out.
+                int signout_row = app.consoles.empty() ? 9 : 10;
                 if (input.up)
                     app.settings_cursor = std::max(0, app.settings_cursor - 1);
                 if (input.down)
@@ -2193,9 +2201,17 @@ int main(int argc, char** argv) {
                     else if (app.settings_cursor == 7)
                         app.settings.sharpness =
                             (app.settings.sharpness + direction + 4) % 4;
-                    else
-                        app.settings.source =
-                            (app.settings.source + direction + 3) % 3;
+                    else {
+                        // Rows 8+ : "Preferred source" (8, only with a linked
+                        // console), then "Debug HUD" (at signout_row - 1).
+                        int src_row = app.consoles.empty() ? -1 : 8;
+                        if (app.settings_cursor == src_row)
+                            app.settings.source =
+                                (app.settings.source + direction + 3) % 3;
+                        else if (app.settings_cursor == signout_row - 1)
+                            app.settings.debug_hud =
+                                app.settings.debug_hud ? 0 : 1;
+                    }
                     save_settings(app.settings);
                 }
                 if (input.b || input.zl) {

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -19,7 +19,7 @@ namespace gnx::stream {
 
 namespace {
 
-constexpr uint32_t kCodeSize = 64 * 1024;
+constexpr uint32_t kCodeSize = 96 * 1024;  // video vsh + video fsh + hud fsh
 constexpr uint32_t kCmdSize = 64 * 1024;
 constexpr uint32_t kDataSize = 0x1000;
 
@@ -28,6 +28,7 @@ constexpr uint32_t kUniformOff = 0x000;   // Transformation UBO (256B aligned)
 constexpr uint32_t kSamplerOff = 0x100;   // sampler descriptor set
 constexpr uint32_t kImageOff = 0x200;     // image descriptor set (luma, chroma)
 constexpr uint32_t kVtxOff = 0x300;       // quad vertex buffer
+constexpr uint32_t kHudVtxOff = 0x380;    // HUD overlay corner quad
 
 struct Vertex {
     float position[3];
@@ -40,6 +41,14 @@ constexpr Vertex kQuad[] = {
     {{-1.0f, -1.0f, 0.0f}, {0.0f, 1.0f}},
     {{+1.0f, -1.0f, 0.0f}, {1.0f, 1.0f}},
     {{+1.0f, +1.0f, 0.0f}, {1.0f, 0.0f}},
+};
+
+// Top-left corner quad for the HUD overlay (deko3d clip space, UV top-left).
+constexpr Vertex kHudQuad[] = {
+    {{-0.98f, +0.98f, 0.0f}, {0.0f, 0.0f}},
+    {{-0.98f, +0.46f, 0.0f}, {0.0f, 1.0f}},
+    {{-0.40f, +0.46f, 0.0f}, {1.0f, 1.0f}},
+    {{-0.40f, +0.98f, 0.0f}, {1.0f, 0.0f}},
 };
 
 // std140 layout for: mat3 yuvmat; vec3 offset; vec4 uv_data;
@@ -210,12 +219,15 @@ bool DkVideoRenderer::init() {
     };
     if (!load_shader(vertex_shader_, "romfs:/shaders/video_vsh.dksh", 0) ||
         !load_shader(fragment_shader_, "romfs:/shaders/video_fsh.dksh",
-                     0x8000)) {
+                     0x8000) ||
+        !load_shader(hud_fsh_, "romfs:/shaders/hud_fsh.dksh", 0x10000)) {
         return false;
     }
 
     // Vertex buffer (static).
     std::memcpy(static_cast<uint8_t*>(data_cpu_) + kVtxOff, kQuad, sizeof(kQuad));
+    std::memcpy(static_cast<uint8_t*>(data_cpu_) + kHudVtxOff, kHudQuad,
+                sizeof(kHudQuad));
 
     // Sampler descriptor (linear, clamp to edge). Written into the descriptor
     // set from the command buffer each frame (canonical deko3d pattern).
@@ -504,6 +516,24 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     cmdbuf_.bindVtxBufferState({DkVtxBufferState{sizeof(Vertex), 0}});
     cmdbuf_.bindVtxBuffer(0, data_gpu_ + kVtxOff, sizeof(kQuad));
 
+    cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
+
+    // --- HUD overlay pass (stage 0): a semi-transparent panel alpha-blended
+    // over the video, top-left. Reuses the video vertex shader; hud_fsh_ fills
+    // the panel. Stage 1 will sample a rasterized-text texture here instead.
+    dk::BlendState hud_blend;
+    hud_blend.setColorBlendOp(DkBlendOp_Add);
+    hud_blend.setSrcColorBlendFactor(DkBlendFactor_SrcAlpha);
+    hud_blend.setDstColorBlendFactor(DkBlendFactor_InvSrcAlpha);
+    hud_blend.setAlphaBlendOp(DkBlendOp_Add);
+    hud_blend.setSrcAlphaBlendFactor(DkBlendFactor_One);
+    hud_blend.setDstAlphaBlendFactor(DkBlendFactor_InvSrcAlpha);
+    dk::ColorState hud_color;
+    hud_color.setBlendEnable(0, true);
+    cmdbuf_.bindBlendStates(0, {hud_blend});
+    cmdbuf_.bindColorState(hud_color);
+    cmdbuf_.bindShaders(DkStageFlag_GraphicsMask, {&vertex_shader_, &hud_fsh_});
+    cmdbuf_.bindVtxBuffer(0, data_gpu_ + kHudVtxOff, sizeof(kHudQuad));
     cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
 
     queue_.submitCommands(cmdbuf_.finishList());

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -523,7 +523,14 @@ void DkVideoRenderer::update_hud(AVFrame* frame) {
     uint64_t now = armGetSystemTick();
     uint64_t freq = armGetSystemTickFreq();
     if (fps_tick_ == 0) fps_tick_ = now;
-    ++fps_frames_;
+    // Count distinct source frames, not present ticks: the renderer re-presents
+    // the held frame every ~60 Hz tick, so counting render passes would read ~60
+    // even for a 30 fps source. A newly decoded frame carries a new surface in
+    // data[0]; a re-presented frame keeps the previous pointer.
+    if (frame->data[0] != fps_last_data_) {
+        ++fps_frames_;
+        fps_last_data_ = frame->data[0];
+    }
     uint64_t dt = now - fps_tick_;
     if (dt >= freq / 2) {  // recompute FPS over ~0.5 s windows
         fps_ = static_cast<float>(fps_frames_) * static_cast<float>(freq) /

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -2,6 +2,10 @@
 
 #include <switch.h>
 
+#define SDL_MAIN_HANDLED
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+
 #include <algorithm>
 #include <array>
 #include <cstdio>
@@ -43,11 +47,12 @@ constexpr Vertex kQuad[] = {
     {{+1.0f, +1.0f, 0.0f}, {1.0f, 0.0f}},
 };
 
-// Top-left corner quad for the HUD overlay (deko3d clip space, UV top-left).
+// Top-left HUD overlay quad (deko3d clip space, UV top-left). Its aspect matches
+// the 512x160 HUD texture on a 16:9 output so the stats text isn't stretched.
 constexpr Vertex kHudQuad[] = {
     {{-0.98f, +0.98f, 0.0f}, {0.0f, 0.0f}},
-    {{-0.98f, +0.46f, 0.0f}, {0.0f, 1.0f}},
-    {{-0.40f, +0.46f, 0.0f}, {1.0f, 1.0f}},
+    {{-0.98f, +0.66f, 0.0f}, {0.0f, 1.0f}},
+    {{-0.40f, +0.66f, 0.0f}, {1.0f, 1.0f}},
     {{-0.40f, +0.98f, 0.0f}, {1.0f, 0.0f}},
 };
 
@@ -239,6 +244,45 @@ bool DkVideoRenderer::init() {
     sdesc.initialize(sampler);
     sampler_desc_ = sdesc;
 
+    // --- Debug HUD text texture (stage 1): a pitch-linear RGBA surface we
+    // compose on the CPU (panel background + stats) and sample in the overlay
+    // pass. Pitch-linear lets the CPU write pixels straight into the memblock
+    // (no staging copy), the same trick the linear video path uses. ---
+    hud_pixels_.assign(kHudTexW * kHudTexH, 0);
+    hud_text_cache_.clear();
+    fps_tick_ = 0;
+    fps_frames_ = 0;
+    {
+        uint32_t stride = kHudTexW * 4;
+        dk::ImageLayout hud_layout;
+        dk::ImageLayoutMaker{dev_}
+            .setFlags(DkImageFlags_UsageLoadStore | DkImageFlags_Usage2DEngine |
+                      DkImageFlags_PitchLinear)
+            .setFormat(DkImageFormat_RGBA8_Unorm)
+            .setDimensions(kHudTexW, kHudTexH)
+            .setPitchStride(stride)
+            .initialize(hud_layout);
+        uint32_t sz = (hud_layout.getSize() + 0xFFF) & ~0xFFFu;
+        hud_memblock_ = dk::MemBlockMaker{dev_, sz}
+                            .setFlags(DkMemBlockFlags_CpuUncached |
+                                      DkMemBlockFlags_GpuCached |
+                                      DkMemBlockFlags_Image)
+                            .create();
+        hud_cpu_ = hud_memblock_.getCpuAddr();
+        hud_image_.initialize(hud_layout, hud_memblock_, 0);
+        hud_desc_.initialize(hud_image_);
+    }
+    // System shared font (pl was initialized in main). A null font falls back to
+    // a panel with no text -- still proves the overlay, and never crashes.
+    if (!hud_font_) {
+        PlFontData fd;
+        if (R_SUCCEEDED(plGetSharedFontByType(&fd, PlSharedFontType_Standard))) {
+            SDL_RWops* rw = SDL_RWFromConstMem(fd.address, fd.size);
+            if (rw) hud_font_ = TTF_OpenFontRW(rw, 1, 28);
+        }
+        if (!hud_font_) logf("deko3d: HUD font unavailable (panel only)");
+    }
+
     initialized_ = true;
     logf("deko3d: initialized (fb %ux%u, %u framebuffers)", fb_width_, fb_height_,
          kFbNum);
@@ -247,6 +291,10 @@ bool DkVideoRenderer::init() {
 
 void DkVideoRenderer::shutdown() {
     if (dev_ && queue_) queue_.waitIdle();
+    if (hud_font_) {
+        TTF_CloseFont(hud_font_);  // also frees the RWops (opened with freesrc=1)
+        hud_font_ = nullptr;
+    }
     mappings_.clear();
     current_mapping_ = -1;
     swapchain_ = nullptr;
@@ -256,6 +304,8 @@ void DkVideoRenderer::shutdown() {
     cmd_memblock_ = nullptr;
     data_memblock_ = nullptr;
     fb_memblock_ = nullptr;
+    hud_memblock_ = nullptr;
+    hud_cpu_ = nullptr;
     dev_ = nullptr;
     initialized_ = false;
     frame_w_ = frame_h_ = 0;
@@ -412,6 +462,83 @@ DkVideoRenderer::FrameMapping* DkVideoRenderer::map_frame(AVFrame* frame,
     return &mappings_.back();
 }
 
+void DkVideoRenderer::blit_text(const char* s, int x, int y) {
+    if (!hud_font_ || !s || !*s) return;
+    SDL_Color white{255, 255, 255, 255};
+    SDL_Surface* surf = TTF_RenderUTF8_Blended(hud_font_, s, white);
+    if (!surf) return;
+    SDL_LockSurface(surf);
+    int bpp = surf->format->BytesPerPixel;
+    for (int j = 0; j < surf->h; ++j) {
+        int ty = y + j;
+        if (ty < 0 || ty >= static_cast<int>(kHudTexH)) continue;
+        auto* rowp = static_cast<uint8_t*>(surf->pixels) + j * surf->pitch;
+        for (int i = 0; i < surf->w; ++i) {
+            int tx = x + i;
+            if (tx < 0 || tx >= static_cast<int>(kHudTexW)) continue;
+            uint32_t p = 0;
+            std::memcpy(&p, rowp + i * bpp, bpp < 4 ? bpp : 4);
+            uint8_t r, g, b, a;
+            SDL_GetRGBA(p, surf->format, &r, &g, &b, &a);
+            if (a == 0) continue;
+            uint32_t& dst = hud_pixels_[ty * kHudTexW + tx];
+            uint8_t dr = dst & 0xFF, dg = (dst >> 8) & 0xFF,
+                    db = (dst >> 16) & 0xFF, da = (dst >> 24) & 0xFF;
+            float af = a / 255.0f, ia = 1.0f - af;
+            uint8_t nr = static_cast<uint8_t>(r * af + dr * ia);
+            uint8_t ng = static_cast<uint8_t>(g * af + dg * ia);
+            uint8_t nb = static_cast<uint8_t>(b * af + db * ia);
+            uint8_t na = static_cast<uint8_t>(a + da * ia);
+            dst = nr | (ng << 8) | (nb << 16) | (static_cast<uint32_t>(na) << 24);
+        }
+    }
+    SDL_UnlockSurface(surf);
+    SDL_FreeSurface(surf);
+}
+
+void DkVideoRenderer::rasterize_hud() {
+    // deko3d RGBA8_Unorm byte order is R,G,B,A -> pack little-endian. Fill the
+    // panel background (black, ~0.55 alpha), then composite the white text.
+    const uint32_t bg = static_cast<uint32_t>(140) << 24;
+    std::fill(hud_pixels_.begin(), hud_pixels_.end(), bg);
+    if (hud_font_) {
+        int y = 8;
+        int skip = TTF_FontLineSkip(hud_font_);
+        size_t start = 0;
+        while (start <= hud_text_cache_.size()) {
+            size_t nl = hud_text_cache_.find('\n', start);
+            std::string line = hud_text_cache_.substr(
+                start, nl == std::string::npos ? std::string::npos : nl - start);
+            blit_text(line.c_str(), 12, y);
+            y += skip;
+            if (nl == std::string::npos) break;
+            start = nl + 1;
+        }
+    }
+    if (hud_cpu_)
+        std::memcpy(hud_cpu_, hud_pixels_.data(), hud_pixels_.size() * 4);
+}
+
+void DkVideoRenderer::update_hud(AVFrame* frame) {
+    uint64_t now = armGetSystemTick();
+    uint64_t freq = armGetSystemTickFreq();
+    if (fps_tick_ == 0) fps_tick_ = now;
+    ++fps_frames_;
+    uint64_t dt = now - fps_tick_;
+    if (dt >= freq / 2) {  // recompute FPS over ~0.5 s windows
+        fps_ = static_cast<float>(fps_frames_) * static_cast<float>(freq) /
+               static_cast<float>(dt);
+        fps_frames_ = 0;
+        fps_tick_ = now;
+    }
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%dx%d\n%.0f fps", frame->width,
+                  frame->height, fps_);
+    if (hud_text_cache_ == buf) return;  // unchanged -> keep the current texture
+    hud_text_cache_ = buf;
+    rasterize_hud();
+}
+
 bool DkVideoRenderer::render(AVFrame* frame) {
     if (!initialized_) return false;
     maybe_rebuild_swapchain();  // follow dock/undock (720p <-> 1080p)
@@ -463,6 +590,10 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     FrameMapping* fm = map_frame(frame, base, handle, size);
     if (!fm) return false;
 
+    // Recompute HUD stats + re-rasterize the text texture now, while the GPU is
+    // idle (render() ends with waitIdle) and before we record any commands.
+    if (hud_enabled_) update_hud(frame);
+
     int slot = queue_.acquireImage(swapchain_);
 
     cmdbuf_.clear();
@@ -476,6 +607,9 @@ bool DkVideoRenderer::render(AVFrame* frame) {
                      sizeof(DkImageDescriptor));
     cmdbuf_.pushData(data_gpu_ + kImageOff + sizeof(DkImageDescriptor),
                      &fm->chroma_desc, sizeof(DkImageDescriptor));
+    // Image descriptor #2 = the HUD text texture (sampled by the overlay pass).
+    cmdbuf_.pushData(data_gpu_ + kImageOff + 2 * sizeof(DkImageDescriptor),
+                     &hud_desc_, sizeof(DkImageDescriptor));
 
     dk::ImageView view{framebuffers_[slot]};
     cmdbuf_.bindRenderTargets({&view});
@@ -500,7 +634,7 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     cmdbuf_.bindDepthStencilState(depth_stencil);
 
     cmdbuf_.bindSamplerDescriptorSet(data_gpu_ + kSamplerOff, 1);
-    cmdbuf_.bindImageDescriptorSet(data_gpu_ + kImageOff, 2);
+    cmdbuf_.bindImageDescriptorSet(data_gpu_ + kImageOff, 3);
     cmdbuf_.barrier(DkBarrier_None,
                     DkInvalidateFlags_Image | DkInvalidateFlags_Descriptors);
 
@@ -518,10 +652,10 @@ bool DkVideoRenderer::render(AVFrame* frame) {
 
     cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
 
-    // --- HUD overlay pass (stage 0): a semi-transparent panel alpha-blended
-    // over the video, top-left. Reuses the video vertex shader; hud_fsh_ fills
-    // the panel. Stage 1 will sample a rasterized-text texture here instead.
-    // Gated by the "Debug HUD" setting.
+    // --- HUD overlay pass (stage 1): sample the rasterized stats texture and
+    // alpha-blend it over the video, top-left. Reuses the video vertex shader;
+    // hud_fsh_ samples image descriptor #2 through sampler #0. Gated by the
+    // "Debug HUD" setting.
     if (hud_enabled_) {
         dk::BlendState hud_blend;
         hud_blend.setColorBlendOp(DkBlendOp_Add);
@@ -536,6 +670,7 @@ bool DkVideoRenderer::render(AVFrame* frame) {
         cmdbuf_.bindColorState(hud_color);
         cmdbuf_.bindShaders(DkStageFlag_GraphicsMask,
                             {&vertex_shader_, &hud_fsh_});
+        cmdbuf_.bindTextures(DkStage_Fragment, 0, {dkMakeTextureHandle(2, 0)});
         cmdbuf_.bindVtxBuffer(0, data_gpu_ + kHudVtxOff, sizeof(kHudQuad));
         cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
     }

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -531,9 +531,18 @@ void DkVideoRenderer::update_hud(AVFrame* frame) {
         fps_frames_ = 0;
         fps_tick_ = now;
     }
-    char buf[64];
-    std::snprintf(buf, sizeof(buf), "%dx%d\n%.0f fps", frame->width,
-                  frame->height, fps_);
+    char buf[160];
+    if (net_valid_.load(std::memory_order_relaxed)) {
+        std::snprintf(buf, sizeof(buf),
+                      "%dx%d\n%.0f fps  %.1f Mbps\nloss %.1f%%  buf %dms",
+                      frame->width, frame->height, fps_,
+                      net_mbps_.load(std::memory_order_relaxed),
+                      net_loss_.load(std::memory_order_relaxed),
+                      net_buffer_ms_.load(std::memory_order_relaxed));
+    } else {
+        std::snprintf(buf, sizeof(buf), "%dx%d\n%.0f fps", frame->width,
+                      frame->height, fps_);
+    }
     if (hud_text_cache_ == buf) return;  // unchanged -> keep the current texture
     hud_text_cache_ = buf;
     rasterize_hud();

--- a/src/switch/stream/dk_video_renderer.cpp
+++ b/src/switch/stream/dk_video_renderer.cpp
@@ -521,20 +521,24 @@ bool DkVideoRenderer::render(AVFrame* frame) {
     // --- HUD overlay pass (stage 0): a semi-transparent panel alpha-blended
     // over the video, top-left. Reuses the video vertex shader; hud_fsh_ fills
     // the panel. Stage 1 will sample a rasterized-text texture here instead.
-    dk::BlendState hud_blend;
-    hud_blend.setColorBlendOp(DkBlendOp_Add);
-    hud_blend.setSrcColorBlendFactor(DkBlendFactor_SrcAlpha);
-    hud_blend.setDstColorBlendFactor(DkBlendFactor_InvSrcAlpha);
-    hud_blend.setAlphaBlendOp(DkBlendOp_Add);
-    hud_blend.setSrcAlphaBlendFactor(DkBlendFactor_One);
-    hud_blend.setDstAlphaBlendFactor(DkBlendFactor_InvSrcAlpha);
-    dk::ColorState hud_color;
-    hud_color.setBlendEnable(0, true);
-    cmdbuf_.bindBlendStates(0, {hud_blend});
-    cmdbuf_.bindColorState(hud_color);
-    cmdbuf_.bindShaders(DkStageFlag_GraphicsMask, {&vertex_shader_, &hud_fsh_});
-    cmdbuf_.bindVtxBuffer(0, data_gpu_ + kHudVtxOff, sizeof(kHudQuad));
-    cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
+    // Gated by the "Debug HUD" setting.
+    if (hud_enabled_) {
+        dk::BlendState hud_blend;
+        hud_blend.setColorBlendOp(DkBlendOp_Add);
+        hud_blend.setSrcColorBlendFactor(DkBlendFactor_SrcAlpha);
+        hud_blend.setDstColorBlendFactor(DkBlendFactor_InvSrcAlpha);
+        hud_blend.setAlphaBlendOp(DkBlendOp_Add);
+        hud_blend.setSrcAlphaBlendFactor(DkBlendFactor_One);
+        hud_blend.setDstAlphaBlendFactor(DkBlendFactor_InvSrcAlpha);
+        dk::ColorState hud_color;
+        hud_color.setBlendEnable(0, true);
+        cmdbuf_.bindBlendStates(0, {hud_blend});
+        cmdbuf_.bindColorState(hud_color);
+        cmdbuf_.bindShaders(DkStageFlag_GraphicsMask,
+                            {&vertex_shader_, &hud_fsh_});
+        cmdbuf_.bindVtxBuffer(0, data_gpu_ + kHudVtxOff, sizeof(kHudQuad));
+        cmdbuf_.draw(DkPrimitive_Quads, 4, 1, 0, 0);
+    }
 
     queue_.submitCommands(cmdbuf_.finishList());
     queue_.presentImage(swapchain_, slot);

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -110,6 +110,7 @@ private:
 
     dk::Shader vertex_shader_;
     dk::Shader fragment_shader_;
+    dk::Shader hud_fsh_;  // HUD overlay (stage 0: flat panel; stage 1: text)
 
     // data_memblock_ sub-allocations (offsets):
     uint32_t vtx_offset_ = 0;        // quad vertex buffer

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include <deko3d.hpp>
@@ -22,6 +23,11 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/frame.h>
 }
+
+// Forward-declared to keep SDL_ttf out of this header (it's a plain pointer
+// member here; the full type comes from SDL_ttf.h in the .cpp).
+struct _TTF_Font;
+typedef struct _TTF_Font TTF_Font;
 
 namespace gnx::stream {
 
@@ -94,6 +100,9 @@ private:
     FrameMapping* map_frame(AVFrame* frame, void* base, uint32_t handle,
                             uint32_t size);  // zero-copy import (cached)
     void update_transform(AVFrame* frame);
+    void update_hud(AVFrame* frame);   // recompute stats, re-rasterize on change
+    void rasterize_hud();              // compose panel bg + text into hud_cpu_
+    void blit_text(const char* s, int x, int y);  // white text onto hud_pixels_
 
     LogFn log_;
     bool initialized_ = false;
@@ -142,6 +151,21 @@ private:
     bool warned_not_hw_ = false;
     bool logged_surface_ = false;
     bool hud_enabled_ = true;  // draw the debug HUD overlay pass
+
+    // Debug HUD text (stage 1): stats composited on the CPU into a pitch-linear
+    // RGBA texture, sampled by hud_fsh_ in the overlay pass.
+    static constexpr uint32_t kHudTexW = 512;
+    static constexpr uint32_t kHudTexH = 160;
+    TTF_Font* hud_font_ = nullptr;
+    dk::UniqueMemBlock hud_memblock_;
+    dk::Image hud_image_;
+    dk::ImageDescriptor hud_desc_;
+    void* hud_cpu_ = nullptr;
+    std::vector<uint32_t> hud_pixels_;   // CPU compose buffer (kHudTexW*kHudTexH)
+    std::string hud_text_cache_;         // last rasterized text (skip if unchanged)
+    uint64_t fps_tick_ = 0;              // armGetSystemTick at last FPS sample
+    int fps_frames_ = 0;
+    float fps_ = 0.0f;
 };
 
 }  // namespace gnx::stream

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -43,6 +43,9 @@ public:
         sharpness_ = level < 0 ? 0 : (level > 3 ? 3 : level);
     }
 
+    // Enable/disable the debug HUD overlay pass (drawn on top of the video).
+    void set_hud_enabled(bool e) { hud_enabled_ = e; }
+
     // Bring up the deko3d device/swapchain. Call after SDL has released the
     // window. Returns false (and logs) on failure.
     bool init();
@@ -138,6 +141,7 @@ private:
     bool color_full_ = false;
     bool warned_not_hw_ = false;
     bool logged_surface_ = false;
+    bool hud_enabled_ = true;  // draw the debug HUD overlay pass
 };
 
 }  // namespace gnx::stream

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -10,6 +10,7 @@
 // The owner suspends SDL (Gfx::suspend) before init() and resumes it after
 // shutdown(); during streaming deko3d owns the framebuffer exclusively.
 
+#include <atomic>
 #include <cstdarg>
 #include <cstdint>
 #include <functional>
@@ -51,6 +52,15 @@ public:
 
     // Enable/disable the debug HUD overlay pass (drawn on top of the video).
     void set_hud_enabled(bool e) { hud_enabled_ = e; }
+
+    // Live network stats for the HUD, fed once per second from the streaming
+    // worker thread (stored atomically; read on the render thread).
+    void set_net_stats(float mbps, float loss_pct, int buffer_ms) {
+        net_mbps_.store(mbps, std::memory_order_relaxed);
+        net_loss_.store(loss_pct, std::memory_order_relaxed);
+        net_buffer_ms_.store(buffer_ms, std::memory_order_relaxed);
+        net_valid_.store(true, std::memory_order_relaxed);
+    }
 
     // Bring up the deko3d device/swapchain. Call after SDL has released the
     // window. Returns false (and logs) on failure.
@@ -166,6 +176,10 @@ private:
     uint64_t fps_tick_ = 0;              // armGetSystemTick at last FPS sample
     int fps_frames_ = 0;
     float fps_ = 0.0f;
+    std::atomic<float> net_mbps_{0.0f};   // set by Engine worker, read by update_hud
+    std::atomic<float> net_loss_{0.0f};
+    std::atomic<int> net_buffer_ms_{0};
+    std::atomic<bool> net_valid_{false};
 };
 
 }  // namespace gnx::stream

--- a/src/switch/stream/dk_video_renderer.hpp
+++ b/src/switch/stream/dk_video_renderer.hpp
@@ -160,7 +160,7 @@ private:
     bool color_full_ = false;
     bool warned_not_hw_ = false;
     bool logged_surface_ = false;
-    bool hud_enabled_ = true;  // draw the debug HUD overlay pass
+    bool hud_enabled_ = false;  // draw the debug HUD overlay pass
 
     // Debug HUD text (stage 1): stats composited on the CPU into a pitch-linear
     // RGBA texture, sampled by hud_fsh_ in the overlay pass.
@@ -174,7 +174,8 @@ private:
     std::vector<uint32_t> hud_pixels_;   // CPU compose buffer (kHudTexW*kHudTexH)
     std::string hud_text_cache_;         // last rasterized text (skip if unchanged)
     uint64_t fps_tick_ = 0;              // armGetSystemTick at last FPS sample
-    int fps_frames_ = 0;
+    int fps_frames_ = 0;                 // distinct frames presented this window
+    const uint8_t* fps_last_data_ = nullptr;  // last frame's surface, for dedup
     float fps_ = 0.0f;
     std::atomic<float> net_mbps_{0.0f};   // set by Engine worker, read by update_hud
     std::atomic<float> net_loss_{0.0f};

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -306,6 +306,7 @@ void Engine::on_video(uint8_t* data, size_t size, void* user) {
     // complete access units and only emits clean, keyframe-anchored frames.
     auto* self = static_cast<Engine*>(user);
     self->last_media_ticks_.store(SDL_GetTicks64(), std::memory_order_relaxed);
+    self->video_bytes_.fetch_add(size, std::memory_order_relaxed);  // HUD bitrate
     bool want_keyframe = false;
     self->jitter_.receive(
         data, size, SDL_GetTicks64(),
@@ -936,6 +937,8 @@ bool Engine::run_peer(GssvSession& session) {
     Uint64 prev_audio_time = SDL_GetTicks64();
     uint32_t prev_audio_frames = 0;
     uint32_t prev_audio_out = 0;
+    uint64_t prev_hud_bytes = 0;               // HUD bitrate window (video bytes)
+    Uint64 prev_hud_time = SDL_GetTicks64();
     Uint64 idr_wait_start = 0;
     Uint64 last_idr_wait_log = 0;
     Uint64 negotiation_started = SDL_GetTicks64();
@@ -1073,15 +1076,32 @@ bool Engine::run_peer(GssvSession& session) {
             uint8_t fraction;
             uint32_t cumulative, highest_ext;
             if (jitter_.report_stats(&fraction, &cumulative, &highest_ext)) {
-                std::lock_guard<std::mutex> lock(peer_mutex_);
-                if (peer_) {
-                    peer_connection_send_receiver_report(peer_, fraction,
-                                                         cumulative, highest_ext, 0);
-                    peer_connection_send_remb(
-                        peer_,
-                        static_cast<uint32_t>(tier_profile(tier_).bitrate_kbps) *
-                            1000u);
+                {
+                    std::lock_guard<std::mutex> lock(peer_mutex_);
+                    if (peer_) {
+                        peer_connection_send_receiver_report(
+                            peer_, fraction, cumulative, highest_ext, 0);
+                        peer_connection_send_remb(
+                            peer_,
+                            static_cast<uint32_t>(tier_profile(tier_).bitrate_kbps) *
+                                1000u);
+                    }
                 }
+#ifdef __SWITCH__
+                // Feed the debug HUD: real bitrate (RTP video bytes over the
+                // window), packet loss (RTCP fraction), audio buffer depth.
+                uint64_t vb = video_bytes_.load(std::memory_order_relaxed);
+                double dt = (now > prev_hud_time)
+                                ? static_cast<double>(now - prev_hud_time)
+                                : 0.0;
+                float mbps = dt > 0.0 ? static_cast<double>(vb - prev_hud_bytes) *
+                                            8.0 / dt / 1000.0
+                                      : 0.0f;
+                prev_hud_bytes = vb;
+                prev_hud_time = now;
+                float loss_pct = static_cast<float>(fraction) * 100.0f / 255.0f;
+                dk_video_.set_net_stats(mbps, loss_pct, audio_.stats().queue_ms);
+#endif
             }
         }
 

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -1341,6 +1341,7 @@ bool Engine::begin_deko_output() {
 #ifdef __SWITCH__
     dk_video_.set_logger([this](const char* m) { log(std::string(m)); });
     dk_video_.set_sharpness(sharpness_);
+    dk_video_.set_hud_enabled(debug_hud_);
     bool ok = dk_video_.init();
     log(ok ? "deko3d output started" : "deko3d output FAILED to start");
     return ok;

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -245,7 +245,7 @@ private:
     // pump_video), in SDL performance-counter ticks: millisecond deadlines
     // quantized to an uneven 16/17 ms grid; the counter keeps the fraction.
     double next_present_counter_ = 0;
-    bool debug_hud_ = true;                 // draw the debug HUD overlay
+    bool debug_hud_ = false;                // draw the debug HUD overlay
     std::atomic<Uint64> last_keyframe_req_{0};
     std::atomic<uint32_t> pli_sent_{0};  // RTCP PLI keyframe requests
 

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -78,6 +78,9 @@ public:
     // renderer. Set from the "sharpness" setting before each stream start.
     void set_sharpness(int level) { sharpness_ = level; }
 
+    // Draw the on-screen debug HUD overlay while streaming. Set before start().
+    void set_debug_hud(bool enabled) { debug_hud_ = enabled; }
+
     EngineState state() const { return state_; }
     std::string status() const;
     std::string error() const;
@@ -241,6 +244,7 @@ private:
     // pump_video), in SDL performance-counter ticks: millisecond deadlines
     // quantized to an uneven 16/17 ms grid; the counter keeps the fraction.
     double next_present_counter_ = 0;
+    bool debug_hud_ = true;                 // draw the debug HUD overlay
     std::atomic<Uint64> last_keyframe_req_{0};
     std::atomic<uint32_t> pli_sent_{0};  // RTCP PLI keyframe requests
 

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -191,6 +191,7 @@ private:
     std::condition_variable video_cv_;  // wakes decode_loop when an AU arrives
     std::deque<std::vector<uint8_t>> video_queue_;
     std::atomic<bool> got_frame_{false};
+    std::atomic<uint64_t> video_bytes_{0};  // RTP video bytes rx (HUD bitrate)
 
     // Decoded-frame handoff (Switch): decode_thread_ decodes into shared_frame_;
     // the render thread (pump_video) takes its own ref into present_frame_ so it


### PR DESCRIPTION
Adds an on-screen **debug overlay** drawn over the video while streaming, with live stats: **resolution, FPS, bitrate, packet loss and audio-buffer depth**. Toggle it in **Settings → Debug HUD** (off by default in `settings.json` terms it's `"debug_hud"`).

Because deko3d owns the display exclusively during streaming (SDL is suspended), the HUD can't be an SDL overlay — it's a **second deko3d pass**: a small alpha-blended panel in the top-left. The stats text is rasterized on the CPU (system shared font via SDL_ttf) into a pitch-linear RGBA texture and sampled by the overlay shader, re-rasterized only when the text changes. If the font can't load it falls back to a panel with no text — never a crash.

Stats sources:
- **Bitrate / loss / buffer** — from the streaming worker once a second (RTP video bytes, RTCP fraction-lost, audio jitter-queue depth).
- **Resolution / FPS** — from the renderer (decoded frame dimensions, present-clock rate).

Scope: a new HUD shader + the deko3d renderer, a little engine stat plumbing, and one Settings row (the row pitch tightens so the longer list still clears the note box). Builds clean from a fresh clone.
