### PR TITLE
fix(xhome): try reachable ICE candidates first (remote play away from home)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ involved.
   highest quality
 - A 5 GHz Wi-Fi connection is recommended
 
+### Remote play from outside your home network
+
+Streaming your own console over the internet also needs the console reachable
+from outside: on the router it is connected to, forward **UDP 9002** (and
+**UDP 3074**) to it, or enable UPnP so it can open those itself. Give the
+console a fixed address first, so the rule cannot end up pointing at a
+different device. On the console, *Remote features* must be on and the power
+mode set to *Instant on*.
+
+Inside your own network none of this is needed.
+
 ## Install
 
 1. Copy `green-nx.nro` to `sdmc:/switch/` on your SD card.

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -79,6 +79,33 @@ std::vector<std::string> local_candidates_from_sdp(const std::string& sdp) {
     return out;
 }
 
+// Address field of "candidate:<foundation> <comp> <proto> <prio> <addr> <port>".
+std::string candidate_address(const std::string& candidate) {
+    std::istringstream fields(candidate);
+    std::vector<std::string> parts;
+    std::string token;
+    while (fields >> token) parts.push_back(token);
+    return parts.size() >= 5 ? parts[4] : std::string();
+}
+
+bool is_private_ipv4(const std::string& address) {
+    unsigned a = 0, b = 0, c = 0, d = 0;
+    if (std::sscanf(address.c_str(), "%u.%u.%u.%u", &a, &b, &c, &d) != 4)
+        return false;
+    return a == 10 || a == 127 || (a == 172 && b >= 16 && b <= 31) ||
+           (a == 192 && b == 168) || (a == 169 && b == 254);
+}
+
+// Same /24 -- enough to tell "this LAN address is on my network" from "this LAN
+// address belongs to a network I am not on".
+bool same_subnet(const std::string& left, const std::string& right) {
+    size_t left_cut = left.rfind('.');
+    size_t right_cut = right.rfind('.');
+    if (left_cut == std::string::npos || right_cut == std::string::npos)
+        return false;
+    return left.compare(0, left_cut, right, 0, right_cut) == 0;
+}
+
 std::string ufrag_from_sdp(const std::string& sdp) {
     size_t at = sdp.find("a=ice-ufrag:");
     if (at == std::string::npos) return "";
@@ -902,6 +929,34 @@ bool Engine::run_peer(GssvSession& session) {
         return true;
     }
 
+    // Try the candidates most likely to work from where we actually are first.
+    // libpeer checks pairs one at a time on a budget of a few seconds each, so
+    // within the negotiation timeout only the first few are ever reached. The
+    // console lists its LAN address first: exactly right at home, and dead
+    // weight from any other network, where it burns the budget before the
+    // routable candidates get a turn. Keep private addresses that are on our
+    // own subnet up front (the home case, which keeps connecting instantly) and
+    // push the rest behind the routable ones.
+    {
+        std::string our_lan;
+        for (const std::string& candidate : local_candidates_from_sdp(munged)) {
+            std::string address = candidate_address(candidate);
+            if (is_private_ipv4(address)) {
+                our_lan = address;
+                break;
+            }
+        }
+        std::stable_partition(
+            remote.begin(), remote.end(),
+            [&our_lan](const std::string& candidate) {
+                std::string address = candidate_address(candidate);
+                if (!is_private_ipv4(address)) return true;  // routable
+                return !our_lan.empty() && same_subnet(address, our_lan);
+            });
+        if (!remote.empty())
+            log("checking " + candidate_address(remote.front()) + " first");
+    }
+
     {
         std::lock_guard<std::mutex> lock(peer_mutex_);
         for (const std::string& candidate : remote)
@@ -1047,8 +1102,10 @@ bool Engine::run_peer(GssvSession& session) {
             log("ICE connected but DTLS/SCTP never completed -- dead media path");
             return false;
         }
+        // Away from home the working pair is rarely the first one tried, and
+        // each pair costs libpeer a few seconds -- 45 s covered very few.
         if (state_ == EngineState::Negotiating &&
-            SDL_GetTicks64() - negotiation_started > 45000) {
+            SDL_GetTicks64() - negotiation_started > 75000) {
             fail("Connection timed out");
             return true;
         }


### PR DESCRIPTION
Remote play works on the home network but times out from any other one — including for people who have already forwarded UDP 9002 and given the console a static address (#27).

### What the logs show

The session comes up, the SDP exchange succeeds and both sides publish usable candidates. The console advertises its LAN address *and* its routable one:

```
remote cand: ... 192.168.0.17 9002 typ host          <- home LAN, dead from outside
remote cand: ... <public> 3074 typ host
remote cand: ... <public> 9002 typ host
remote cand: ... <public> 9002 typ srflx raddr 192.168.0.17 rport 9002
```

Then ICE sits in `checking` for the entire negotiation window and gives up, with no STUN response ever arriving.

The console lists its LAN address **first**. That is exactly right at home — and dead weight from anywhere else. libpeer checks candidate pairs one at a time on a budget of a few seconds each, so the 45 s timeout only ever covered the first few pairs, all of them unreachable ones, and the routable candidates never got a turn. It works at home precisely because there the first candidate is the right one.

### Change

Order the remote candidates by how likely they are to work from where we are: routable addresses first, private ones behind them unless they share our own /24 — so the home path still connects on the first pair, instantly. Raise the negotiation timeout to 75 s so a couple of slow pairs no longer exhaust it, and log which candidate is tried first, so a failure report says how far it got.

Also add a README section on what remote play needs from the network (UDP 9002/3074 or UPnP, fixed address, Instant on). That requirement is currently folklore in the issues and nowhere in the docs — #27 and #24 both start there.

### Honesty about verification

Confirmed from logs that the reordering takes effect (the first candidate checked becomes the routable one) and that the build is clean. My own out-of-home session only started working once the port was forwarded **and** this build was running, so I cannot separate the two from a single data point. For #27, where the port is already open, this is the missing half — @FigueroaD23 would be the real test.
