### PR TITLE
feat(stream): launch ad-supported titles from the xgpuwebf2p offering (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,17 @@ involved.
   **zero-copy GPU rendering** (deko3d) — the decoded surface goes straight
   from the decoder to the screen
 - Opus audio, 60 fps video, three quality tiers (720p / 1080p / 1080p HQ)
+- **Ad-supported streaming** for free-to-play titles: no subscription needed,
+  streamed from Microsoft's ad-supported offering (sessions are capped by the
+  server, and the console tells you before you start)
 
 ## Requirements
 
 - A Nintendo Switch running the [Atmosphère](https://github.com/Atmosphere-NX/Atmosphere) custom firmware
-- An active **Xbox Game Pass** subscription — every tier (Essential, Premium,
-  Ultimate) includes Cloud Gaming; Ultimate streams the largest catalog at the
-  highest quality
+- An **Xbox Game Pass** subscription for the subscription catalog — every tier
+  (Essential, Premium, Ultimate) includes Cloud Gaming; Ultimate streams the
+  largest catalog at the highest quality. Games you already own stream without
+  one, and so do free-to-play titles offered with ads
 - A 5 GHz Wi-Fi connection is recommended
 
 ## Install
@@ -69,6 +73,7 @@ development on a PC:
 ./build/pc/greennx login            # device-code sign-in
 ./build/pc/greennx games            # the playable library, with names
 ./build/pc/greennx search cyberpunk # the whole catalog, with availability
+./build/pc/greennx stream-test FORTNITE --ads   # ad-supported offering
 ```
 
 ### Layout

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ involved.
 
 - Microsoft **device-code sign-in** (no password typed on console); tokens
   cached on SD
-- **Game library** with box-art covers, search, quality settings
+- **Game library** with box-art covers, quality settings, and search that
+  covers the **whole xCloud catalog** — titles you cannot stream yet are
+  flagged with what they need (Game Pass, ad-supported), and a game that is
+  not on xCloud at all says so instead of "nothing found"
 - **Native WebRTC streaming**: ICE (Teredo), DTLS-SRTP, SCTP data channels,
   RTP video/audio, NACK/PLI recovery — implemented on-console
 - **Hardware H.264 decoding** (NVDEC via FFmpeg's NVTEGRA hwaccel) with
@@ -60,7 +63,13 @@ docker run --rm -v "$PWD":/src -w /src devkitpro/devkita64 make
 
 The result is `green-nx.nro`. A small desktop harness
 (`make -f Makefile.pc`) builds the core (auth/catalog/signaling) for
-development on a PC.
+development on a PC:
+
+```sh
+./build/pc/greennx login            # device-code sign-in
+./build/pc/greennx games            # the playable library, with names
+./build/pc/greennx search cyberpunk # the whole catalog, with availability
+```
 
 ### Layout
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -56,6 +56,17 @@ int cmd_whoami(gnx::XboxAuth& auth) {
     return 0;
 }
 
+// The catalog as the library sees it: the cloud offering, plus whatever the
+// ad-supported one will stream to this account folded in.
+std::vector<gnx::Game> load_catalog(gnx::Http& http,
+                                    const gnx::StreamingCredentials& creds) {
+    std::vector<gnx::Game> catalog = gnx::fetch_catalog(http, creds.cloud);
+    if (creds.cloud_f2p)
+        gnx::merge_ad_supported(catalog,
+                                gnx::fetch_catalog(http, *creds.cloud_f2p));
+    return catalog;
+}
+
 // How the account can reach a title, in the same words the library uses.
 std::string availability(const gnx::Game& game) {
     std::string label;
@@ -65,8 +76,10 @@ std::string availability(const gnx::Game& game) {
     };
     if (game.owned) add("owned");
     if (game.in_subscription) add("in your Game Pass");
-    else if (game.subscription) add("needs Game Pass");
-    if (game.ad_supported) add("ad-supported");
+    else if (game.subscription && !game.needs_ad_offering())
+        add("needs Game Pass");
+    if (game.needs_ad_offering()) add("free with ads");
+    else if (game.ad_supported) add("ad-supported");
     return label.empty() ? "unavailable" : label;
 }
 
@@ -76,7 +89,7 @@ int cmd_games(gnx::XboxAuth& auth, bool with_names) {
     std::printf("Cloud endpoint: %s\n", credentials.cloud.host.c_str());
 
     gnx::Http http;
-    std::vector<gnx::Game> catalog = gnx::fetch_catalog(http, credentials.cloud);
+    std::vector<gnx::Game> catalog = load_catalog(http, credentials);
     std::vector<gnx::Game*> playable;
     for (gnx::Game& game : catalog)
         if (game.playable()) playable.push_back(&game);
@@ -103,7 +116,7 @@ int cmd_games(gnx::XboxAuth& auth, bool with_names) {
 int cmd_search(gnx::XboxAuth& auth, const std::string& query) {
     gnx::StreamingCredentials credentials = auth.fetch_streaming_credentials();
     gnx::Http http;
-    std::vector<gnx::Game> catalog = gnx::fetch_catalog(http, credentials.cloud);
+    std::vector<gnx::Game> catalog = load_catalog(http, credentials);
 
     std::string key = gnx::search_key(query);
     if (key.empty()) {
@@ -141,16 +154,28 @@ int cmd_search(gnx::XboxAuth& auth, const std::string& query) {
 // Exercises the session signaling end to end (minus WebRTC): create a
 // session with the high-quality (tizen) fingerprint, wait for provisioning,
 // authenticate the connection, then tear it down.
-int cmd_stream_test(gnx::XboxAuth& auth, const std::string& title_id) {
+int cmd_stream_test(gnx::XboxAuth& auth, const std::string& title_id,
+                    bool ad_supported) {
     std::printf("Fetching streaming credentials...\n");
     gnx::StreamingCredentials credentials = auth.fetch_streaming_credentials();
     gnx::Http http;
 
-    std::printf("Cleaning up stale sessions...\n");
-    gnx::GssvSession::cleanup_stale_sessions(http, credentials.cloud);
+    // Ad-supported titles only start against the xgpuwebf2p offering, so the
+    // harness has to be able to aim at it -- that path is otherwise only
+    // reachable from the console.
+    if (ad_supported && !credentials.cloud_f2p) {
+        std::printf("This account has no ad-supported offering.\n");
+        return 1;
+    }
+    const gnx::EndpointCredentials& endpoint =
+        ad_supported ? *credentials.cloud_f2p : credentials.cloud;
+    std::printf("Offering: %s\n", ad_supported ? "xgpuwebf2p (ads)"
+                                               : "xgpuweb");
 
-    gnx::GssvSession session(http, credentials.cloud,
-                             gnx::QualityTier::P1080HQ);
+    std::printf("Cleaning up stale sessions...\n");
+    gnx::GssvSession::cleanup_stale_sessions(http, endpoint);
+
+    gnx::GssvSession session(http, endpoint, gnx::QualityTier::P1080HQ);
     std::printf("Starting session for %s (1080p HQ tier)...\n",
                 title_id.c_str());
     session.start_cloud(title_id);
@@ -212,13 +237,14 @@ int main(int argc, char** argv) {
             return cmd_search(auth, query);
         }
         if (command == "stream-test" && argc > 2)
-            return cmd_stream_test(auth, argv[2]);
+            return cmd_stream_test(auth, argv[2],
+                                   argc > 3 && std::string(argv[3]) == "--ads");
     } catch (const std::exception& error) {
         std::fprintf(stderr, "error: %s\n", error.what());
         return 1;
     }
     std::printf(
         "usage: greennx <login|logout|whoami|games|ids|search <QUERY>|"
-        "stream-test <TITLEID>>\n");
+        "stream-test <TITLEID> [--ads]>\n");
     return 2;
 }

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -1,11 +1,14 @@
 // PC test harness for the green-nx core: sign in and list playable games
 // from the terminal, before any Switch code exists.
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "../core/auth.hpp"
 #include "../core/catalog.hpp"
@@ -53,27 +56,85 @@ int cmd_whoami(gnx::XboxAuth& auth) {
     return 0;
 }
 
+// How the account can reach a title, in the same words the library uses.
+std::string availability(const gnx::Game& game) {
+    std::string label;
+    auto add = [&label](const char* text) {
+        if (!label.empty()) label += " + ";
+        label += text;
+    };
+    if (game.owned) add("owned");
+    if (game.in_subscription) add("in your Game Pass");
+    else if (game.subscription) add("needs Game Pass");
+    if (game.ad_supported) add("ad-supported");
+    return label.empty() ? "unavailable" : label;
+}
+
 int cmd_games(gnx::XboxAuth& auth, bool with_names) {
     std::printf("Fetching streaming credentials...\n");
     gnx::StreamingCredentials credentials = auth.fetch_streaming_credentials();
     std::printf("Cloud endpoint: %s\n", credentials.cloud.host.c_str());
 
     gnx::Http http;
-    std::vector<gnx::Game> games =
-        gnx::fetch_playable_titles(http, credentials.cloud);
-    std::printf("Playable titles: %zu\n\n", games.size());
+    std::vector<gnx::Game> catalog = gnx::fetch_catalog(http, credentials.cloud);
+    std::vector<gnx::Game*> playable;
+    for (gnx::Game& game : catalog)
+        if (game.playable()) playable.push_back(&game);
+    std::printf("Catalog: %zu titles, %zu playable\n\n", catalog.size(),
+                playable.size());
 
     if (with_names) {
         std::printf("Resolving names from the Store catalog...\n\n");
-        gnx::fetch_names(http, games);
+        gnx::fetch_names(http, playable);
     }
-    for (const gnx::Game& game : games) {
-        if (game.name.empty())
-            std::printf("  %s\n", game.title_id.c_str());
+    for (const gnx::Game* game : playable) {
+        if (game->name.empty())
+            std::printf("  %s\n", game->title_id.c_str());
         else
-            std::printf("  %-40s  %s\n", game.title_id.c_str(),
-                        game.name.c_str());
+            std::printf("  %-40s  %s\n", game->title_id.c_str(),
+                        game->name.c_str());
     }
+    return 0;
+}
+
+// Searches the whole catalog the way the library's search box does, then
+// resolves names for the hits only -- the check that "is X on xCloud, and what
+// would I need to play it?" works without downloading 2400 store entries.
+int cmd_search(gnx::XboxAuth& auth, const std::string& query) {
+    gnx::StreamingCredentials credentials = auth.fetch_streaming_credentials();
+    gnx::Http http;
+    std::vector<gnx::Game> catalog = gnx::fetch_catalog(http, credentials.cloud);
+
+    std::string key = gnx::search_key(query);
+    if (key.empty()) {
+        std::printf("Nothing searchable in \"%s\".\n", query.c_str());
+        return 1;  // an empty key matches every title -- refuse, don't resolve
+    }
+    std::vector<gnx::Game*> hits;
+    for (gnx::Game& game : catalog)
+        if (gnx::matches_query(game, key)) hits.push_back(&game);
+
+    if (hits.empty()) {
+        std::printf("\"%s\" is not on xCloud — not with Game Pass, not as a "
+                    "game you own.\n", query.c_str());
+        return 0;
+    }
+    std::printf("%zu of %zu titles match \"%s\":\n\n", hits.size(),
+                catalog.size(), query.c_str());
+    // Each batch of 20 is ~1 MB of store metadata, so a broad query resolves
+    // a screenful and lists the rest by id -- same rule as the console UI.
+    constexpr size_t kResolveLimit = 40;
+    if (hits.size() > kResolveLimit)
+        std::printf("(resolving names for the first %zu)\n\n", kResolveLimit);
+    std::vector<gnx::Game*> resolve(
+        hits.begin(),
+        hits.begin() + static_cast<std::ptrdiff_t>(
+                           std::min(hits.size(), kResolveLimit)));
+    gnx::fetch_names(http, resolve);
+    for (const gnx::Game* game : hits)
+        std::printf("  %-34s  %-44s  %s\n", game->title_id.c_str(),
+                    (game->name.empty() ? "?" : game->name).c_str(),
+                    availability(*game).c_str());
     return 0;
 }
 
@@ -145,6 +206,11 @@ int main(int argc, char** argv) {
         if (command == "whoami") return cmd_whoami(auth);
         if (command == "games") return cmd_games(auth, true);
         if (command == "ids") return cmd_games(auth, false);
+        if (command == "search" && argc > 2) {
+            std::string query = argv[2];
+            for (int i = 3; i < argc; ++i) query += std::string(" ") + argv[i];
+            return cmd_search(auth, query);
+        }
         if (command == "stream-test" && argc > 2)
             return cmd_stream_test(auth, argv[2]);
     } catch (const std::exception& error) {
@@ -152,6 +218,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     std::printf(
-        "usage: greennx <login|logout|whoami|games|ids|stream-test <TITLEID>>\n");
+        "usage: greennx <login|logout|whoami|games|ids|search <QUERY>|"
+        "stream-test <TITLEID>>\n");
     return 2;
 }

--- a/src/core/catalog.cpp
+++ b/src/core/catalog.cpp
@@ -97,6 +97,14 @@ std::vector<Game> fetch_catalog(Http& http, const EndpointCredentials& cloud) {
                 if (program == sub) game.in_subscription = true;
         }
 
+        // "userPrograms" is what the account holds, as opposed to what the
+        // title is offered under. F2P here means this account may stream it
+        // ad-supported -- the cloud offering reports it empty, the f2p one
+        // fills it in, which is why both catalogs have to be fetched.
+        for (const json& program : details.value("userPrograms", json::array()))
+            if (program.is_string() && program.get<std::string>() == "F2P")
+                game.ad_granted = true;
+
         games.push_back(std::move(game));
     }
 
@@ -108,6 +116,44 @@ std::vector<Game> fetch_catalog(Http& http, const EndpointCredentials& cloud) {
                             }),
                 games.end());
     return games;
+}
+
+void merge_ad_supported(std::vector<Game>& catalog,
+                        const std::vector<Game>& ads) {
+    std::unordered_map<std::string, Game*> by_title;
+    for (Game& game : catalog) by_title[game.title_id] = &game;
+
+    std::vector<Game> extras;
+    for (const Game& ad : ads) {
+        // Everything the offering hands back is ad-supported by definition,
+        // but only what the account is entitled to there will actually start.
+        if (!ad.owned && !ad.in_subscription && !ad.ad_granted) continue;
+
+        auto found = by_title.find(ad.title_id);
+        if (found == by_title.end()) {
+            Game game = ad;
+            game.ad_supported = true;
+            game.ad_playable = true;
+            // The offering answers only for itself: whether the same title is
+            // owned or covered by a plan is the cloud catalog's business, and
+            // it does not list this one at all.
+            game.owned = false;
+            game.in_subscription = false;
+            extras.push_back(std::move(game));
+            continue;
+        }
+        found->second->ad_supported = true;
+        found->second->ad_playable = true;
+        found->second->ad_granted = ad.ad_granted;
+        if (ad.max_session_secs > 0)
+            found->second->max_session_secs = ad.max_session_secs;
+    }
+
+    catalog.insert(catalog.end(), extras.begin(), extras.end());
+    std::sort(catalog.begin(), catalog.end(),
+              [](const Game& a, const Game& b) {
+                  return a.title_id < b.title_id;
+              });
 }
 
 std::string search_key(const std::string& text) {

--- a/src/core/catalog.cpp
+++ b/src/core/catalog.cpp
@@ -1,6 +1,7 @@
 #include "catalog.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -53,8 +54,7 @@ std::vector<HomeConsole> fetch_home_consoles(
     return consoles;
 }
 
-std::vector<Game> fetch_playable_titles(Http& http,
-                                        const EndpointCredentials& cloud) {
+std::vector<Game> fetch_catalog(Http& http, const EndpointCredentials& cloud) {
     HttpResponse response =
         http.get(cloud.host + "/v2/titles",
                  {"Accept: application/json",
@@ -73,19 +73,30 @@ std::vector<Game> fetch_playable_titles(Http& http,
         if (title_id.empty()) continue;
 
         const json details = entry.value("details", json::object());
-        bool playable = details.value("hasEntitlement", false);
-        if (!playable) {
-            const json programs = details.value("programs", json::array());
-            const json subs = details.value("userSubscriptions", json::array());
-            for (const json& program : programs)
-                for (const json& sub : subs)
-                    if (program == sub) { playable = true; break; }
-        }
-        if (!playable) continue;
-
         Game game;
         game.title_id = title_id;
         game.product_id = details.value("productId", "");
+        game.owned = details.value("hasEntitlement", false);
+        game.max_session_secs = details.value("maxSessionLengthInSeconds", 0);
+
+        // "programs" lists what the title is offered under, "userSubscriptions"
+        // what the account holds; their intersection is Game Pass access. The
+        // subscription programs are backend codenames (GPULTIMATE, CALLISTO,
+        // DIA, EUROPA, TRITON, FERDINAND, IO, GANYMEDE...) and new ones appear
+        // over time, so anything that is not one of the known non-subscription
+        // programs counts as one rather than matching a hardcoded list.
+        const json programs = details.value("programs", json::array());
+        const json subs = details.value("userSubscriptions", json::array());
+        for (const json& program : programs) {
+            if (!program.is_string()) continue;
+            const std::string name = program.get<std::string>();
+            if (name == "F2P") game.ad_supported = true;
+            else if (name != "BYOG" && name != "EARLYACCESS")
+                game.subscription = true;
+            for (const json& sub : subs)
+                if (program == sub) game.in_subscription = true;
+        }
+
         games.push_back(std::move(game));
     }
 
@@ -99,13 +110,38 @@ std::vector<Game> fetch_playable_titles(Http& http,
     return games;
 }
 
+std::string search_key(const std::string& text) {
+    std::string key;
+    key.reserve(text.size());
+    for (unsigned char c : text)
+        if (std::isalnum(c)) key += static_cast<char>(std::tolower(c));
+    return key;
+}
+
+bool matches_query(const Game& game, const std::string& query_key) {
+    if (query_key.empty()) return true;
+    return search_key(game.name).find(query_key) != std::string::npos ||
+           search_key(game.title_id).find(query_key) != std::string::npos;
+}
+
 void fetch_names(Http& http, std::vector<Game>& games,
                  const std::string& market, const std::string& language) {
-    // displaycatalog accepts comma-separated bigIds; keep batches modest.
+    std::vector<Game*> pointers;
+    pointers.reserve(games.size());
+    for (Game& game : games) pointers.push_back(&game);
+    fetch_names(http, pointers, market, language);
+}
+
+void fetch_names(Http& http, const std::vector<Game*>& games,
+                 const std::string& market, const std::string& language) {
+    // displaycatalog accepts comma-separated bigIds; keep batches modest --
+    // the Details template runs to ~53 KB per product, so 20 already means a
+    // ~1 MB response to hold in memory on the console.
     constexpr size_t kBatch = 20;
     std::unordered_map<std::string, Game*> by_product;
-    for (Game& game : games)
-        if (!game.product_id.empty()) by_product[game.product_id] = &game;
+    for (Game* game : games)
+        if (!game->product_id.empty() && game->name.empty())
+            by_product[game->product_id] = game;
 
     std::vector<std::string> ids;
     ids.reserve(by_product.size());

--- a/src/core/catalog.hpp
+++ b/src/core/catalog.hpp
@@ -20,12 +20,20 @@ struct Game {
     bool subscription = false;     // offered under some Game Pass tier
     bool in_subscription = false;  // ... a tier this account actually holds
     bool ad_supported = false;     // F2P program — no subscription needed
+    bool ad_granted = false;       // userPrograms holds F2P for this title
+    bool ad_playable = false;      // the xgpuwebf2p offering will stream it
     int max_session_secs = 0;      // ad-supported runs are capped; 0 = no cap
 
-    // What the library grid lists. Ad-supported titles are deliberately left
-    // out: they stream from the xgpuwebf2p offering and the launcher only
-    // ever opens sessions against the cloud one.
-    bool playable() const { return owned || in_subscription; }
+    // What the library grid lists.
+    bool playable() const { return owned || in_subscription || ad_playable; }
+
+    // Playable, but only through the ad-supported offering — the session has
+    // to be created against StreamingCredentials::cloud_f2p rather than the
+    // regular cloud one. Owning the game (or having it in your plan) wins:
+    // that path carries no ads and no session cap.
+    bool needs_ad_offering() const {
+        return ad_playable && !owned && !in_subscription;
+    }
 };
 
 // Every title the xCloud backend knows about (~2400), each tagged with how —
@@ -34,6 +42,15 @@ struct Game {
 // Game::playable() holds; the rest exist so search can answer "is this game
 // on xCloud at all, and what would I need to play it?".
 std::vector<Game> fetch_catalog(Http& http, const EndpointCredentials& cloud);
+
+// Folds the ad-supported offering's catalog into the cloud one. Both come
+// from fetch_catalog(), each with its own offering credentials: the flags in
+// `ads` describe what xgpuwebf2p will stream to this account, which is the
+// only way to know a title is playable without a subscription. Titles the
+// offering carries but the cloud catalog does not are appended, so a
+// Game Pass-less account still gets a library instead of an empty grid.
+void merge_ad_supported(std::vector<Game>& catalog,
+                        const std::vector<Game>& ads);
 
 // Casefolded, punctuation-free form of a title or query. Title ids are the
 // squashed product name (FORZAHORIZON5, ASSASSINSCREEDSHADOWS), so comparing

--- a/src/core/catalog.hpp
+++ b/src/core/catalog.hpp
@@ -13,15 +13,48 @@ struct Game {
     std::string product_id;  // Microsoft Store bigId, for metadata lookup
     std::string name;        // filled by fetch_names()
     std::string box_art_url;
+
+    // How this account can reach the title. Several can be true at once: a
+    // game you own is usually in the subscription catalog as well.
+    bool owned = false;            // hasEntitlement — your own copy
+    bool subscription = false;     // offered under some Game Pass tier
+    bool in_subscription = false;  // ... a tier this account actually holds
+    bool ad_supported = false;     // F2P program — no subscription needed
+    int max_session_secs = 0;      // ad-supported runs are capped; 0 = no cap
+
+    // What the library grid lists. Ad-supported titles are deliberately left
+    // out: they stream from the xgpuwebf2p offering and the launcher only
+    // ever opens sessions against the cloud one.
+    bool playable() const { return owned || in_subscription; }
 };
 
-// Titles the signed-in account can actually play (entitlement or subscription),
-// from the xCloud backend's /v2/titles.
-std::vector<Game> fetch_playable_titles(Http& http,
-                                        const EndpointCredentials& cloud);
+// Every title the xCloud backend knows about (~2400), each tagged with how —
+// or whether — this account can play it, from /v2/titles. Sorted by title id,
+// duplicates removed. Callers that only want the library show the ones where
+// Game::playable() holds; the rest exist so search can answer "is this game
+// on xCloud at all, and what would I need to play it?".
+std::vector<Game> fetch_catalog(Http& http, const EndpointCredentials& cloud);
+
+// Casefolded, punctuation-free form of a title or query. Title ids are the
+// squashed product name (FORZAHORIZON5, ASSASSINSCREEDSHADOWS), so comparing
+// on this key lets "forza horizon" match a title whose name has not been
+// resolved yet — i.e. search covers the whole catalog with no network at all.
+std::string search_key(const std::string& text);
+
+// True when the query key appears in the game's name or title id. An empty
+// query matches everything.
+bool matches_query(const Game& game, const std::string& query_key);
 
 // Fills name/box_art_url from the public Microsoft Store display catalog.
-// Batched; no authentication required.
+// Batched; no authentication required. Entries that already carry a name are
+// skipped, so resolving a search result set repeatedly stays cheap.
+//
+// Resolving the whole catalog this way is not viable: the Details template
+// weighs ~53 KB per product, i.e. ~130 MB for every title. Resolve the
+// playable list plus whatever the user is actually looking at.
+void fetch_names(Http& http, const std::vector<Game*>& games,
+                 const std::string& market = "US",
+                 const std::string& language = "en-US");
 void fetch_names(Http& http, std::vector<Game>& games,
                  const std::string& market = "US",
                  const std::string& language = "en-US");

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -491,10 +491,10 @@ void apply_region(const Settings& settings) {
 // ---- persistence ----------------------------------------------------------
 
 // v1 lacked boxArt, v2 held only the playable titles and no availability
-// flags: both force a refresh. The v3 cache is the whole catalog (~2400
-// entries, ~300 KB), which is what search needs to answer "is this game on
-// xCloud?" without going back to the network.
-constexpr int kGamesCacheVersion = 3;
+// flags, v3 predates the ad-supported offering: all force a refresh. The
+// cache is the whole catalog (~2400 entries, ~300 KB), which is what search
+// needs to answer "is this game on xCloud?" without going back to the network.
+constexpr int kGamesCacheVersion = 4;
 
 void save_games_cache(const std::vector<Game>& games) {
     json list = json::array();
@@ -507,6 +507,8 @@ void save_games_cache(const std::vector<Game>& games) {
                         {"sub", game.subscription},
                         {"mySub", game.in_subscription},
                         {"ads", game.ad_supported},
+                        {"adsGranted", game.ad_granted},
+                        {"adsPlayable", game.ad_playable},
                         {"maxSession", game.max_session_secs}});
     std::ofstream out(user_path("games.json"), std::ios::trunc);
     out << json{{"version", kGamesCacheVersion}, {"games", list}}.dump();
@@ -530,6 +532,8 @@ std::vector<Game> load_games_cache() {
         game.subscription = entry.value("sub", false);
         game.in_subscription = entry.value("mySub", false);
         game.ad_supported = entry.value("ads", false);
+        game.ad_granted = entry.value("adsGranted", false);
+        game.ad_playable = entry.value("adsPlayable", false);
         game.max_session_secs = entry.value("maxSession", 0);
         if (!game.title_id.empty()) games.push_back(std::move(game));
     }
@@ -692,6 +696,18 @@ void start_library_load(App& app, bool force_refresh) {
             // grid still lists only the playable ones, but search can then
             // say what a title would need instead of "nothing found".
             std::vector<Game> games = fetch_catalog(http, credentials.cloud);
+            // The ad-supported offering is a separate catalog with its own
+            // entitlements; without it an account with no Game Pass plan has
+            // no way to know what it can stream for free. Non-fatal: the
+            // offering is missing for plenty of accounts and regions.
+            if (credentials.cloud_f2p) {
+                try {
+                    merge_ad_supported(
+                        games, fetch_catalog(http, *credentials.cloud_f2p));
+                } catch (const std::exception&) {
+                    // Leave the cloud catalog as it is.
+                }
+            }
             std::vector<Game*> playable;
             for (Game& game : games)
                 if (game.playable()) playable.push_back(&game);
@@ -1131,7 +1147,8 @@ void launch_stream(App& app, bool home) {
     if (app.launching_home)
         app.engine->start_home(selected_console(app).server_id, tier, locale);
     else
-        app.engine->start(app.launch_game.title_id, tier, locale);
+        app.engine->start(app.launch_game.title_id, tier, locale,
+                          app.launch_game.needs_ad_offering());
     app.stream_hint_until = SDL_GetTicks() + 8000;
     app.scene = Scene::Stream;
 #endif
@@ -1152,8 +1169,9 @@ void draw_loading(App& app) {
                           gfx::FontSize::Note, gfx::kTextDim);
 }
 
-// What a search hit the account cannot launch would need, in two words for
-// the card corner. Playable titles never show one -- the whole grid is theirs.
+// How a card streams, in two words for its bottom edge. Only shown when the
+// answer is not the obvious one: either the account cannot launch it, or it
+// launches ad-supported rather than from the library proper.
 const char* availability_badge(const Game& game) {
     if (game.ad_supported) return "Free · ads";
     if (game.subscription) return "Game Pass";
@@ -1168,12 +1186,17 @@ std::vector<std::pair<std::string, gfx::Color>> availability_chips(
     if (game.owned) chips.push_back({"You own it", gfx::kFocus});
     if (game.in_subscription)
         chips.push_back({"In your Game Pass", gfx::kFocus});
-    else if (game.subscription)
+    else if (game.subscription && !game.needs_ad_offering())
+        // A title you can already stream free with ads is not "missing" a
+        // subscription; leading with what it needs would just be wrong.
         chips.push_back({"Needs Game Pass", gfx::kWarn});
     // The session cap that comes with ad-supported play is spelled out in the
     // footnote instead: chips share one row with quality and favorite, and a
     // title can be owned, in the catalog and ad-supported all at once.
-    if (game.ad_supported) chips.push_back({"Ad-supported", gfx::kWarn});
+    if (game.ad_supported)
+        chips.push_back({game.needs_ad_offering() ? "Free with ads"
+                                                  : "Ad-supported",
+                         gfx::kWarn});
     if (chips.empty())
         chips.push_back({"Not available to this account", gfx::kError});
     return chips;
@@ -1198,9 +1221,11 @@ void draw_card(App& app, const Game& game, const SDL_Rect& card,
 
     // A search hit this account cannot launch is dimmed and labelled with
     // what it would take, so the grid never mixes "play this" with "you
-    // can't play this" silently (#41).
-    if (!game.playable()) {
-        app.gfx.fill(dst, {gfx::kBg.r, gfx::kBg.g, gfx::kBg.b, 150});
+    // can't play this" silently (#41). Ad-supported titles are playable, so
+    // they keep their colour but still say how they stream.
+    if (!game.playable() || game.needs_ad_offering()) {
+        if (!game.playable())
+            app.gfx.fill(dst, {gfx::kBg.r, gfx::kBg.g, gfx::kBg.b, 150});
         const char* badge = availability_badge(game);
         SDL_Rect plate = {dst.x, dst.y + dst.h - 44, dst.w, 44};
         app.gfx.fill(plate, gfx::kBar);
@@ -1487,17 +1512,19 @@ void draw_detail(App& app) {
     draw_focus_frames(app, focused);
 
     std::string note;
-    if (game.playable())
+    if (game.needs_ad_offering())
+        note = "Streams free with ads";
+    else if (game.playable())
         note = "Streams in your account's language · change in Settings";
-    else if (game.ad_supported)
-        note = "Ad-supported streaming isn't wired up on the console yet";
     else if (game.subscription)
         note = "Included with Game Pass — this account has no plan covering it";
     else
         note = "This title isn't streamable from Xbox Cloud Gaming";
-    if (game.ad_supported && game.max_session_secs > 0)
-        note += " · " + std::to_string(game.max_session_secs / 60) +
-                "-minute sessions";
+    // The cap is the server's, not ours: an ad-supported session is cut at
+    // maxSessionLengthInSeconds, so say it before the stream starts.
+    if (game.needs_ad_offering() && game.max_session_secs > 0)
+        note += " · sessions end after " +
+                std::to_string(game.max_session_secs / 60) + " minutes";
     app.gfx.text(note, rx, app.consoles.empty() ? 680 : 792,
                  gfx::FontSize::Small, gfx::kFaint);
 

--- a/src/switch/main.cpp
+++ b/src/switch/main.cpp
@@ -30,6 +30,7 @@
 #include "../core/catalog.hpp"
 #include "covers.hpp"
 #include "gfx.hpp"
+#include "names.hpp"
 
 #ifdef GNX_NATIVE_STREAM
 #include "stream/engine.hpp"
@@ -355,6 +356,7 @@ struct App {
     std::vector<HintHit> hint_hits;  // footer chips recorded for touch taps
     UiSound ui_sound;
     std::unique_ptr<Covers> covers;
+    std::unique_ptr<Names> names;  // lazy name lookup for catalog search hits
     std::unique_ptr<XboxAuth> auth;
 
     Scene scene = Scene::Splash;
@@ -372,6 +374,7 @@ struct App {
     // library
     std::vector<Game> games;
     std::vector<int> visible;  // indices into games for the active tab + search
+    int playable_visible = 0;  // of those, how many can actually be launched
     std::string query;
     int cursor = 0;
     LibraryTab tab = LibraryTab::All;
@@ -487,7 +490,11 @@ void apply_region(const Settings& settings) {
 
 // ---- persistence ----------------------------------------------------------
 
-constexpr int kGamesCacheVersion = 2;  // v1 lacked boxArt: force a refresh
+// v1 lacked boxArt, v2 held only the playable titles and no availability
+// flags: both force a refresh. The v3 cache is the whole catalog (~2400
+// entries, ~300 KB), which is what search needs to answer "is this game on
+// xCloud?" without going back to the network.
+constexpr int kGamesCacheVersion = 3;
 
 void save_games_cache(const std::vector<Game>& games) {
     json list = json::array();
@@ -495,7 +502,12 @@ void save_games_cache(const std::vector<Game>& games) {
         list.push_back({{"titleId", game.title_id},
                         {"productId", game.product_id},
                         {"name", game.name},
-                        {"boxArt", game.box_art_url}});
+                        {"boxArt", game.box_art_url},
+                        {"owned", game.owned},
+                        {"sub", game.subscription},
+                        {"mySub", game.in_subscription},
+                        {"ads", game.ad_supported},
+                        {"maxSession", game.max_session_secs}});
     std::ofstream out(user_path("games.json"), std::ios::trunc);
     out << json{{"version", kGamesCacheVersion}, {"games", list}}.dump();
 }
@@ -514,6 +526,11 @@ std::vector<Game> load_games_cache() {
         game.product_id = entry.value("productId", "");
         game.name = entry.value("name", "");
         game.box_art_url = entry.value("boxArt", "");
+        game.owned = entry.value("owned", false);
+        game.subscription = entry.value("sub", false);
+        game.in_subscription = entry.value("mySub", false);
+        game.ad_supported = entry.value("ads", false);
+        game.max_session_secs = entry.value("maxSession", 0);
         if (!game.title_id.empty()) games.push_back(std::move(game));
     }
     return games;
@@ -629,6 +646,8 @@ void start_signin(App& app) {
 void start_library_load(App& app, bool force_refresh) {
     app.load_state = 0;
     app.status = "Connecting to Xbox...";
+    // Pending lookups belong to the library we are about to replace.
+    if (app.names) app.names->reset();
     app.worker = std::thread([&app, force_refresh] {
         try {
             if (!force_refresh) {
@@ -668,13 +687,28 @@ void start_library_load(App& app, bool force_refresh) {
                 std::fprintf(f, "%s\n", console_log.c_str());
                 std::fclose(f);
             }
-            std::vector<Game> games =
-                fetch_playable_titles(http, credentials.cloud);
+            // The backend hands over its whole catalog (~2400 titles), not
+            // just what this account can play. Keep all of it: the library
+            // grid still lists only the playable ones, but search can then
+            // say what a title would need instead of "nothing found".
+            std::vector<Game> games = fetch_catalog(http, credentials.cloud);
+            std::vector<Game*> playable;
+            for (Game& game : games)
+                if (game.playable()) playable.push_back(&game);
             app.status = "Resolving names and covers (" +
+                         std::to_string(playable.size()) + " of " +
                          std::to_string(games.size()) + " titles)...";
-            fetch_names(http, games);
+            // Only the playable ones: the full catalog would be ~130 MB of
+            // store metadata. The rest resolve lazily as search surfaces them.
+            fetch_names(http, playable);
+            // Playable first, alphabetically -- that block is the library
+            // grid. Catalog-only titles follow, ordered by id, and are only
+            // ever reached through search.
             std::sort(games.begin(), games.end(),
                       [](const Game& a, const Game& b) {
+                          if (a.playable() != b.playable())
+                              return a.playable();
+                          if (!a.playable()) return a.title_id < b.title_id;
                           const std::string& left =
                               a.name.empty() ? a.title_id : a.name;
                           const std::string& right =
@@ -729,6 +763,7 @@ void switch_account(App& app, const std::string& id) {
     app.games.clear();
     app.visible.clear();
     app.consoles.clear();
+    if (app.names) app.names->reset();  // lookups belong to the old account
     app.favorites = load_id_list("favorites.json");
     app.history = load_id_list("history.json");
     app.gamertag.clear();
@@ -759,13 +794,18 @@ void add_account(App& app) {
     switch_account(app, g_accounts.back().id);
 }
 
+// Rebuild `visible` for the active tab and query.
+//
+// Without a query the grid is the playable library, exactly as before. With
+// one, the search also reaches the titles this account cannot play: those hit
+// the grid after the playable matches, flagged with what they would need
+// (#41). Matching runs on search_key(), so "forza horizon" finds
+// FORZAHORIZON5 whether or not its store name has been resolved yet.
 void apply_filter(App& app) {
     app.visible.clear();
-    std::string needle = lowercase(app.query);
+    std::string needle = search_key(app.query);
     auto matches = [&](const Game& game) {
-        return needle.empty() ||
-               lowercase(game.name).find(needle) != std::string::npos ||
-               lowercase(game.title_id).find(needle) != std::string::npos;
+        return matches_query(game, needle);
     };
 
     if (app.tab == LibraryTab::Consoles) {
@@ -777,14 +817,25 @@ void apply_filter(App& app) {
         }
     } else {
         for (int i = 0; i < static_cast<int>(app.games.size()); ++i) {
-            if (app.tab == LibraryTab::Favorites &&
-                !is_favorite(app, app.games[i].title_id))
+            const Game& game = app.games[i];
+            // Catalog-only titles are search results, never browsable rows:
+            // with no query they would bury the library under ~2400 cards.
+            // Favorites are exempt -- pinning one is an explicit choice, and
+            // a game that vanishes the moment you star it reads as a bug.
+            if (!game.playable() && needle.empty() &&
+                app.tab != LibraryTab::Favorites)
                 continue;
-            if (matches(app.games[i])) app.visible.push_back(i);
+            if (app.tab == LibraryTab::Favorites &&
+                !is_favorite(app, game.title_id))
+                continue;
+            if (matches(game)) app.visible.push_back(i);
         }
     }
     app.cursor = std::min(app.cursor,
                           std::max(0, static_cast<int>(app.visible.size()) - 1));
+    app.playable_visible = 0;
+    for (int i : app.visible)
+        if (app.games[i].playable()) ++app.playable_visible;
 }
 
 std::string keyboard_input(const std::string& initial) {
@@ -1101,6 +1152,33 @@ void draw_loading(App& app) {
                           gfx::FontSize::Note, gfx::kTextDim);
 }
 
+// What a search hit the account cannot launch would need, in two words for
+// the card corner. Playable titles never show one -- the whole grid is theirs.
+const char* availability_badge(const Game& game) {
+    if (game.ad_supported) return "Free · ads";
+    if (game.subscription) return "Game Pass";
+    return "Unavailable";
+}
+
+// The same answer with room to breathe, for the detail screen's meta chips.
+// A title can qualify several ways at once, so this fills a small list.
+std::vector<std::pair<std::string, gfx::Color>> availability_chips(
+    const Game& game) {
+    std::vector<std::pair<std::string, gfx::Color>> chips;
+    if (game.owned) chips.push_back({"You own it", gfx::kFocus});
+    if (game.in_subscription)
+        chips.push_back({"In your Game Pass", gfx::kFocus});
+    else if (game.subscription)
+        chips.push_back({"Needs Game Pass", gfx::kWarn});
+    // The session cap that comes with ad-supported play is spelled out in the
+    // footnote instead: chips share one row with quality and favorite, and a
+    // title can be owned, in the catalog and ad-supported all at once.
+    if (game.ad_supported) chips.push_back({"Ad-supported", gfx::kWarn});
+    if (chips.empty())
+        chips.push_back({"Not available to this account", gfx::kError});
+    return chips;
+}
+
 // One library card. The focused card scales 1.08x (230x345 -> 248x372,
 // centered), gets border+glow and a name plate under it (card 1a layer 1+4).
 void draw_card(App& app, const Game& game, const SDL_Rect& card,
@@ -1108,11 +1186,30 @@ void draw_card(App& app, const Game& game, const SDL_Rect& card,
     SDL_Rect dst = card;
     if (focused) dst = {card.x - 9, card.y - 13, kCardW + 18, kCardH + 27};
 
+    // Catalog hits arrive with an id and nothing else; resolve the name (and
+    // with it the box art) for the cards actually on screen, like covers do.
+    if (game.name.empty()) app.names->request(game);
+
     SDL_Texture* cover = app.covers->get(game.title_id, game.box_art_url);
     if (cover)
         app.gfx.draw_texture(cover, dst);
     else
         draw_cover_fallback(app, game, dst, gfx::FontSize::Huge);
+
+    // A search hit this account cannot launch is dimmed and labelled with
+    // what it would take, so the grid never mixes "play this" with "you
+    // can't play this" silently (#41).
+    if (!game.playable()) {
+        app.gfx.fill(dst, {gfx::kBg.r, gfx::kBg.g, gfx::kBg.b, 150});
+        const char* badge = availability_badge(game);
+        SDL_Rect plate = {dst.x, dst.y + dst.h - 44, dst.w, 44};
+        app.gfx.fill(plate, gfx::kBar);
+        app.gfx.text_centered(badge, plate.x + plate.w / 2, plate.y + 8,
+                              gfx::FontSize::Small,
+                              game.subscription || game.ad_supported
+                                  ? gfx::kWarn
+                                  : gfx::kError);
+    }
 
     if (is_favorite(app, game.title_id)) {
         SDL_Rect badge = {dst.x + 8, dst.y + 8, 44, 44};
@@ -1247,7 +1344,14 @@ void draw_library(App& app) {
     }
 
     std::string info = std::to_string(app.visible.size()) + " games";
-    if (!app.query.empty()) info += "  ·  \"" + app.query + "\"";
+    if (!app.query.empty()) {
+        // With a query the count mixes the library with the wider catalog;
+        // spell the split out instead of implying they are all playable.
+        int extra = static_cast<int>(app.visible.size()) - app.playable_visible;
+        info = std::to_string(app.playable_visible) + " playable";
+        if (extra > 0) info += "  ·  " + std::to_string(extra) + " in catalog";
+        info += "  ·  \"" + app.query + "\"";
+    }
     app.gfx.text(info,
                  gfx::kWidth - kGridX -
                      app.gfx.text_width(info, gfx::FontSize::Small),
@@ -1255,9 +1359,12 @@ void draw_library(App& app) {
 
     if (app.visible.empty()) {
         if (!app.query.empty())
+            // Searching the whole catalog turns "nothing found" into a real
+            // answer: the title is not on xCloud at all (#41).
             draw_empty_state(app, "", gfx::kText,
-                             "Nothing found for \"" + app.query + "\"",
-                             "Press", "Y", "to search again");
+                             "\"" + app.query + "\" isn't on Xbox Cloud Gaming",
+                             "Not with Game Pass or as a game you own · press",
+                             "Y", "to search again");
         else if (app.tab == LibraryTab::Favorites)
             draw_empty_state(app, "★", gfx::kWarn, "No favorites yet",
                              "Press", "X", "on any game to pin it here");
@@ -1310,6 +1417,7 @@ void draw_detail(App& app) {
         app.detail_index >= static_cast<int>(app.games.size()))
         return;
     const Game& game = app.games[app.detail_index];
+    if (game.name.empty()) app.names->request(game);
 
     SDL_Rect cover_rect = {kGridX, 120, 520, 780};
     SDL_Texture* cover = app.covers->get(game.title_id, game.box_art_url);
@@ -1338,8 +1446,10 @@ void draw_detail(App& app) {
         app.gfx.text(label, cx2 + 18, 238, gfx::FontSize::Small, color);
         cx2 += w + 20;
     };
-    meta_chip("Xbox Cloud Gaming", gfx::kTextDim);
-    meta_chip(kQualityLabels[app.settings.quality], gfx::kTextDim);
+    for (const auto& [label, color] : availability_chips(game))
+        meta_chip(label, color);
+    if (game.playable())
+        meta_chip(kQualityLabels[app.settings.quality], gfx::kTextDim);
     if (fav) meta_chip("★ Favorite", gfx::kWarn);
 
     // Action buttons, 640 wide. Buttons don't scale on focus — only
@@ -1347,9 +1457,13 @@ void draw_detail(App& app) {
     // drawn only with a linked console (card 1f visibility rule).
     const char* fav_label = fav ? "★ Remove favorite" : "★ Add favorite";
     SDL_Rect play = {rx, 400, 640, 96};
-    app.gfx.fill(play, gfx::kAccent);
-    app.gfx.text_centered("Play", play.x + 320, play.y + 24,
-                          gfx::FontSize::Body, gfx::kText);
+    // Search reaches titles the account cannot stream; the button says so
+    // rather than starting a session that the backend would refuse.
+    bool can_play = game.playable();
+    app.gfx.fill(play, can_play ? gfx::kAccent : gfx::kSurface);
+    app.gfx.text_centered(can_play ? "Play" : "Can't play this yet",
+                          play.x + 320, play.y + 24, gfx::FontSize::Body,
+                          can_play ? gfx::kText : gfx::kTextDim);
     SDL_Rect favbtn = {rx, 520, 640, 96};
     app.gfx.fill(favbtn, gfx::kSurface);
     app.gfx.text_centered(fav_label, favbtn.x + 320, favbtn.y + 24,
@@ -1372,9 +1486,20 @@ void draw_detail(App& app) {
                                                 : source;
     draw_focus_frames(app, focused);
 
-    app.gfx.text("Streams in your account's language · change in Settings",
-                 rx, app.consoles.empty() ? 680 : 792, gfx::FontSize::Small,
-                 gfx::kFaint);
+    std::string note;
+    if (game.playable())
+        note = "Streams in your account's language · change in Settings";
+    else if (game.ad_supported)
+        note = "Ad-supported streaming isn't wired up on the console yet";
+    else if (game.subscription)
+        note = "Included with Game Pass — this account has no plan covering it";
+    else
+        note = "This title isn't streamable from Xbox Cloud Gaming";
+    if (game.ad_supported && game.max_session_secs > 0)
+        note += " · " + std::to_string(game.max_session_secs / 60) +
+                "-minute sessions";
+    app.gfx.text(note, rx, app.consoles.empty() ? 680 : 792,
+                 gfx::FontSize::Small, gfx::kFaint);
 
     draw_hints(app, {{"A", "Select", true}, {"B", "Back"}});
 }
@@ -2200,6 +2325,7 @@ int main(int argc, char** argv) {
     app.ui_sound.init();  // menu navigation ticks (best-effort; ignored on fail)
     SDL_Joystick* joystick = SDL_JoystickOpen(0);
     app.covers = std::make_unique<Covers>(app.gfx, data_path("covers"));
+    app.names = std::make_unique<Names>();
     load_accounts();  // registry + migration; sets the active account
     app.auth = std::make_unique<XboxAuth>(user_path("tokens.json"));
     app.auth->set_abort_flag(&app.abort_http);
@@ -2473,7 +2599,7 @@ int main(int argc, char** argv) {
                         // Cycle the preferred source: Ask -> xCloud -> Xbox.
                         app.settings.source = (app.settings.source + 1) % 3;
                         save_settings(app.settings);
-                    } else {
+                    } else if (game.playable()) {
                         app.launch_game = game;
                         push_history(app, app.launch_game.title_id);
                         if (!app.consoles.empty() &&
@@ -2799,6 +2925,8 @@ int main(int argc, char** argv) {
             app.ui_sound.play(1.0f);
 
         app.covers->pump();
+        // A resolved name can change what the query matches, so re-filter.
+        if (app.names->pump(app.games)) apply_filter(app);
         app.gfx.begin_frame();
         switch (app.scene) {
             case Scene::Splash: draw_splash(app); break;
@@ -2847,6 +2975,7 @@ int main(int argc, char** argv) {
     breadcrumb("webrtc shut down");
 #endif
     app.covers.reset();
+    app.names.reset();
     breadcrumb("covers stopped");
     // Every libcurl handle has to be gone before socketExit(). A handle keeps
     // its TLS connections open in its own cache, and socketExit() closes bsd:u

--- a/src/switch/names.cpp
+++ b/src/switch/names.cpp
@@ -1,0 +1,96 @@
+#include "names.hpp"
+
+#include <unordered_map>
+
+#include "../core/http.hpp"
+
+namespace gnx {
+
+namespace {
+
+// One displaycatalog round trip is ~1 MB for 20 products, so a batch this
+// size keeps memory bounded while still resolving a screenful in one go.
+constexpr size_t kBatch = 20;
+
+}  // namespace
+
+Names::Names() : thread_(&Names::worker, this) {}
+
+Names::~Names() {
+    quit_ = true;
+    wake_.notify_all();
+    if (thread_.joinable()) thread_.join();
+}
+
+void Names::request(const Game& game) {
+    if (game.product_id.empty() || !game.name.empty()) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (requested_.insert(game.product_id).second) {
+        jobs_.push_back(game.product_id);
+        wake_.notify_one();
+    }
+}
+
+void Names::reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    jobs_.clear();
+    requested_.clear();
+    done_.clear();
+}
+
+bool Names::pump(std::vector<Game>& games) {
+    std::vector<Game> resolved;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (done_.empty()) return false;
+        resolved.swap(done_);
+    }
+
+    std::unordered_map<std::string, const Game*> by_product;
+    for (const Game& game : resolved)
+        if (!game.name.empty()) by_product[game.product_id] = &game;
+    if (by_product.empty()) return false;  // every lookup in this batch missed
+
+    bool changed = false;
+    for (Game& game : games) {
+        auto found = by_product.find(game.product_id);
+        if (found == by_product.end() || !game.name.empty()) continue;
+        game.name = found->second->name;
+        game.box_art_url = found->second->box_art_url;
+        changed = true;
+    }
+    return changed;
+}
+
+void Names::worker() {
+    Http http;
+    http.set_abort_flag(&quit_);  // unblock an in-flight lookup on shutdown
+    while (!quit_) {
+        std::vector<Game> batch;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            wake_.wait(lock, [&] { return quit_ || !jobs_.empty(); });
+            if (quit_) return;
+            while (!jobs_.empty() && batch.size() < kBatch) {
+                Game stub;
+                stub.product_id = std::move(jobs_.front());
+                jobs_.pop_front();
+                batch.push_back(std::move(stub));
+            }
+        }
+
+        busy_ = true;
+        try {
+            fetch_names(http, batch);
+        } catch (const std::exception&) {
+            // Metadata is best-effort: the ids stay in requested_ so a failed
+            // batch is not retried in a loop, and the cards keep their id.
+        }
+        busy_ = false;
+
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (Game& game : batch) done_.push_back(std::move(game));
+    }
+}
+
+}  // namespace gnx

--- a/src/switch/names.hpp
+++ b/src/switch/names.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+
+#include "../core/catalog.hpp"
+
+namespace gnx {
+
+// Resolves display names and box art for catalog entries on demand.
+//
+// The playable library is resolved up front at load time, but search reaches
+// the whole ~2400-title catalog and resolving all of that would pull ~130 MB
+// of store metadata. So the entries the user is actually looking at get
+// resolved here instead, a batch at a time and off the UI thread: request()
+// queues an id, pump() copies whatever came back into the library. Same shape
+// as Covers, which does this for the images.
+class Names {
+public:
+    Names();
+    ~Names();
+
+    // Queue a title whose name is still unknown. Cheap to call every frame:
+    // ids already queued (or already looked up, hit or miss) are ignored.
+    void request(const Game& game);
+
+    // Main thread: apply finished lookups to games. True if anything changed,
+    // which is the caller's cue to re-sort or re-filter.
+    bool pump(std::vector<Game>& games);
+
+    // A lookup is in flight — the UI shows this as a "resolving names" note.
+    bool busy() const { return busy_; }
+
+    // Forget everything: the library was reloaded or the account changed, so
+    // ids withheld as "already requested" must be allowed through again.
+    void reset();
+
+private:
+    void worker();
+
+    std::thread thread_;
+    std::atomic<bool> quit_{false};
+    std::atomic<bool> busy_{false};
+    std::mutex mutex_;
+    std::condition_variable wake_;
+    std::deque<std::string> jobs_;                // product ids to look up
+    std::unordered_set<std::string> requested_;   // queued or already answered
+    std::vector<Game> done_;                      // stubs carrying the answers
+};
+
+}  // namespace gnx

--- a/src/switch/stream/engine.cpp
+++ b/src/switch/stream/engine.cpp
@@ -125,14 +125,16 @@ void Engine::log(const std::string& line) {
 }
 
 void Engine::start(const std::string& title_id, QualityTier tier,
-                   const std::string& locale) {
+                   const std::string& locale, bool ad_supported) {
     home_server_id_.clear();
+    ad_supported_ = ad_supported;
     start_common(title_id, tier, locale);
 }
 
 void Engine::start_home(const std::string& server_id, QualityTier tier,
                         const std::string& locale) {
     home_server_id_ = server_id;
+    ad_supported_ = false;
     start_common("(your console)", tier, locale);
 }
 
@@ -615,7 +617,23 @@ void Engine::worker() {
                         : "Signing in to xCloud...");
         log("fetching streaming credentials");
         StreamingCredentials creds = auth_.fetch_streaming_credentials();
-        cloud_ = home ? creds.home : creds.cloud;
+        // Ad-supported titles live in their own offering and will not start
+        // against the regular cloud token, so a missing f2p login has to be
+        // its own failure rather than a silent fall back to a session the
+        // backend would refuse.
+        if (ad_supported_ && !home && !creds.cloud_f2p) {
+            log("xgpuwebf2p login unavailable");
+            fail("Ad-supported streaming is not available for this account");
+            return;
+        }
+        if (home) {
+            cloud_ = creds.home;
+        } else if (ad_supported_) {
+            cloud_ = *creds.cloud_f2p;
+            log("using the ad-supported offering");
+        } else {
+            cloud_ = creds.cloud;
+        }
         // Without a host every request goes out as a bare path, which curl
         // rejects as a malformed URL -- a useless error for the one thing that
         // actually went wrong: the remote-play login did not come back.

--- a/src/switch/stream/engine.hpp
+++ b/src/switch/stream/engine.hpp
@@ -58,8 +58,12 @@ public:
     // exit, after every Engine is gone; no Engine may be created afterwards.
     static void global_shutdown();
 
+    // ad_supported picks the xgpuwebf2p offering instead of the regular
+    // cloud one: that is how a title streams without a Game Pass plan (with
+    // ads, and with the server-side session cap that comes with it).
     void start(const std::string& title_id, QualityTier tier,
-               const std::string& locale = "en-US");
+               const std::string& locale = "en-US",
+               bool ad_supported = false);
     // Remote play from your own console (xhome offering): the target is the
     // console's serverId; the game is whatever the console runs.
     void start_home(const std::string& server_id, QualityTier tier,
@@ -163,6 +167,7 @@ private:
     EndpointCredentials cloud_;
     std::string title_id_;
     std::string home_server_id_;  // non-empty selects the home (xhome) path
+    bool ad_supported_ = false;   // selects the xgpuwebf2p offering
     QualityTier tier_ = QualityTier::P1080HQ;
     std::string locale_ = "en-US";  // streamed console's system language
     float audio_gain_ = 1.0f;       // forwarded to AudioPlayer::set_gain


### PR DESCRIPTION
Follow-up to #64, as promised there — the launch half of #41. **Stacked on that PR**, so until it merges the diff here shows both commits; only [`e3c32dc`](https://github.com/luishidalgoa/green-nx/commit/e3c32dc) belongs to this one.

`credentials.cloud_f2p` has been fetched on every sign-in **since 1.0.0 and read by nothing**. Ad-supported titles could be flagged after #64, but never started: a session for them only provisions against the `xgpuwebf2p` offering, not the regular cloud one.

## What changes

The ad-supported catalog is fetched alongside the cloud one and folded in (`merge_ad_supported`). The offering answers for itself — what it lists, and grants via `userPrograms: ["F2P"]`, is what it will actually stream — so those titles become playable, and titles it carries that the cloud catalog does not are appended. **An account with no Game Pass plan and no owned games gets a library instead of an empty grid**, which is the case this offering exists for.

`Engine::start()` now takes which offering to use. Owning the title, or having it in your plan, still wins: that path carries no ads and no session cap, so `needs_ad_offering()` only selects the f2p offering when it is the sole way in. A missing f2p login fails with its own message rather than quietly building a session the backend would refuse.

The detail screen says the stream is free with ads and — since the cap is the server's to enforce, not ours — how long the session lasts before it ends (`maxSessionLengthInSeconds`, 3600 on the one title I can see). Cache goes to v4.

## Verification

I could not build this locally (no devkitPro/Docker on my machine), but **CI builds it clean** — the `switch` job is green on this PR. It still needs a run on real hardware. What I could check beyond the build:

**The critical assumption is confirmed against the live backend.** I replicated `GssvSession::start_cloud()` in a script and pointed it at the ad-supported offering:

```
xgpuwebf2p -> https://uks.core.gssv-play-prod.xboxlive.com
POST /v5/sessions/cloud/play (FORTNITE) -> HTTP 202
  sessionPath: v5/sessions/cloud/4CDE5905-...
  [ 0] state: ReadyToConnect
DELETE session -> HTTP 200
```

So the offering provisions with its own token, through the same `/v5/sessions/cloud/play` shape, and reaches `ReadyToConnect` on the first poll. The session was torn down immediately; nothing was streamed, so WebRTC negotiation on that offering is still unproven.

The flag logic is simulated against real `/v2/titles` dumps of both offerings. On my account the merge is a no-op in practice — Fortnite comes back with `hasEntitlement: true`, so `needs_ad_offering()` is **false for all 2442 titles** and it keeps launching through the regular offering exactly as today. Simulating an account with no entitlement and no plan gives the intended result: Fortnite becomes the only playable title and routes through the f2p offering.

## Caveats

- **The new engine branch is not exercised by my account** — precisely because nothing needs it. It wants testing by someone without Game Pass, or against a title they do not own.
- The ad-supported offering returns **exactly one title (Fortnite)** for me, in UK South. I have no way to tell how much that varies by region or account.
- `PC harness: stream-test <TITLEID> --ads` aims at the offering explicitly, which is how I would test this without a console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
